### PR TITLE
Update to API version 1.185.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.100.0]
+
+### Added
+
+- Add Firewall Groups endpoint.
+- Add the new Node groups.
+- Add `php_sessions_spread_enabled`, `automatic_borg_repositories_prune_enabled` and `php_settings` properties to the `Cluster` model.
+- Add `CustomPhpModuleName` enum, to easily see which extensions are available.
+- Add `is_default` property to the `CustomConfigSnippet` model.
+
+### Changed
+
+- Allow underscores in the name of a custom config snippet instead of a dash.
+- Allow `null` as password for UNIX users to limit to SSH key login only. 
+- Update to [API version 1.185.3](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.185.3-2023-07-21).
+
 ## [1.99.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.183** version of the API.
+This client was built for and tested on the **1.185.3** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.99.0';
+    private const VERSION = '1.100.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -17,6 +17,7 @@ use Cyberfusion\ClusterApi\Endpoints\Databases;
 use Cyberfusion\ClusterApi\Endpoints\DatabaseUserGrants;
 use Cyberfusion\ClusterApi\Endpoints\DatabaseUsers;
 use Cyberfusion\ClusterApi\Endpoints\DomainRouters;
+use Cyberfusion\ClusterApi\Endpoints\FirewallGroups;
 use Cyberfusion\ClusterApi\Endpoints\FpmPools;
 use Cyberfusion\ClusterApi\Endpoints\FtpUsers;
 use Cyberfusion\ClusterApi\Endpoints\Health;
@@ -107,6 +108,11 @@ class ClusterApi
     public function databaseUserGrants(): DatabaseUserGrants
     {
         return new DatabaseUserGrants($this->client);
+    }
+
+    public function firewallGroups(): FirewallGroups
+    {
+        return new FirewallGroups($this->client);
     }
 
     public function fpmPools(): FpmPools

--- a/src/Endpoints/FirewallGroups.php
+++ b/src/Endpoints/FirewallGroups.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Endpoints;
+
+use Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Cyberfusion\ClusterApi\Models\FirewallGroup;
+use Cyberfusion\ClusterApi\Request;
+use Cyberfusion\ClusterApi\Response;
+use Cyberfusion\ClusterApi\Support\ListFilter;
+
+class FirewallGroups extends Endpoint
+{
+    /**
+     * @throws RequestException
+     */
+    public function list(?ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('firewall-groups?%s', $filter->toQuery()));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'firewallGroups' => array_map(
+                fn (array $data) => (new FirewallGroup())->fromArray($data),
+                $response->getData()
+            ),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('firewall-groups/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'firewallGroup' => (new FirewallGroup())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function create(FirewallGroup $firewallGroup): Response
+    {
+        $this->validateRequired($firewallGroup, 'create', [
+            'name',
+            'ip_networks',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('firewall-groups')
+            ->setBody(
+                $this->filterFields($firewallGroup->toArray(), [
+                    'name',
+                    'ip_networks',
+                    'cluster_id',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'firewallGroup' => (new FirewallGroup())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function update(FirewallGroup $firewallGroup): Response
+    {
+        $this->validateRequired($firewallGroup, 'update', [
+            'name',
+            'ip_networks',
+            'id',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PUT)
+            ->setUrl(sprintf('firewall-groups/%d', $firewallGroup->getId()))
+            ->setBody(
+                $this->filterFields($firewallGroup->toArray(), [
+                    'name',
+                    'ip_networks',
+                    'id',
+                    'cluster_id',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'firewallGroup' => (new FirewallGroup())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('firewall-groups/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -105,7 +105,6 @@ class UnixUsers extends Endpoint
     {
         $this->validateRequired($unixUser, 'create', [
             'username',
-            'password',
             'cluster_id',
         ]);
 
@@ -149,7 +148,6 @@ class UnixUsers extends Endpoint
     {
         $this->validateRequired($unixUser, 'update', [
             'username',
-            'password',
             'id',
             'cluster_id',
             'unix_id',

--- a/src/Enums/CustomPhpModuleName.php
+++ b/src/Enums/CustomPhpModuleName.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Enums;
+
+class CustomPhpModuleName
+{
+    public const APCU = 'apcu';
+    public const BCMATH = 'bcmath';
+    public const IMAGICK = 'imagick';
+    public const INTL = 'intl';
+    public const LDAP = 'ldap';
+    public const MCRYPT = 'mcrypt';
+    public const PGSQL = 'pgsql';
+    public const REDIS = 'redis';
+    public const SSH2 = 'ssh2';
+    public const SQLITE3 = 'sqlite3';
+    public const SQLSRV = 'sqlsrv';
+    public const XDEBUG = 'xdebug';
+    public const XMLRPC = 'xmlrpc';
+}

--- a/src/Enums/NodeGroup.php
+++ b/src/Enums/NodeGroup.php
@@ -6,14 +6,26 @@ class NodeGroup
 {
     public const ADMIN = 'Admin';
     public const APACHE = 'Apache';
-    public const NGINX = 'nginx';
-    public const DOVECOT = 'Dovecot';
-    public const MARIADB = 'MariaDB';
-    public const POSTGRESQL = 'PostgreSQL';
-    public const MAIN = 'Main';
-    public const PHP = 'PHP';
-    public const PASSENGER = 'Passenger';
-    public const REDIS = 'Redis';
     public const BORG = 'Borg';
+    public const COMPOSER = 'Composer';
+    public const DOVECOT = 'Dovecot';
     public const FAST_REDIRECT = 'Fast Redirect';
+    public const FFMPEG = 'FFmpeg';
+    public const GHOST_SCRIPT = 'Ghostscript';
+    public const GNU_MAILUTILS = 'GNU Mailutils';
+    public const HA_PROXY = 'HAProxy';
+    public const IMAGE_MAGICK = 'ImageMagick';
+    public const KERNEL_CARE = 'KernelCare';
+    public const LIBRE_OFFICE = 'LibreOffice';
+    public const MAIN = 'Main';
+    public const MARIADB = 'MariaDB';
+    public const NGINX = 'nginx';
+    public const PASSENGER = 'Passenger';
+    public const PHP = 'PHP';
+    public const POSTGRESQL = 'PostgreSQL';
+    public const PRO_FTPD = 'ProFTPD';
+    public const PUPPETEER = 'Puppeteer';
+    public const REDIS = 'Redis';
+    public const WKHTMLTOPDF = 'wkhtmltopdf';
+    public const WP_CLI = 'WP-CLI';
 }

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -12,6 +12,7 @@ class Cluster extends ClusterModel
     private ?string $unixUsersHomeDirectory = null;
     private array $phpVersions = [];
     private array $customPhpModulesNames = [];
+    private array $phpSettings = [];
     private ?bool $phpIoncubeEnabled = null;
     private array $nodejsVersions = [];
     private ?string $customerId = null;
@@ -21,6 +22,8 @@ class Cluster extends ClusterModel
     private ?bool $malwareToolkitScansEnabled = null;
     private ?bool $bubblewrapToolkitEnabled = null;
     private ?bool $syncToolkitEnabled = null;
+    private ?bool $automaticBorgRepositoriesPruneEnabled = null;
+    private ?bool $phpSessionSpreadEnabled = null;
     private ?string $description = null;
     private ?int $id = null;
     private ?string $createdAt = null;
@@ -92,6 +95,18 @@ class Cluster extends ClusterModel
     public function setCustomPhpModulesNames(array $customPhpModulesNames): self
     {
         $this->customPhpModulesNames = $customPhpModulesNames;
+
+        return $this;
+    }
+
+    public function getPhpSettings(): array
+    {
+        return $this->phpSettings;
+    }
+
+    public function setPhpSettings(array $phpSettings): self
+    {
+        $this->phpSettings = $phpSettings;
 
         return $this;
     }
@@ -215,6 +230,30 @@ class Cluster extends ClusterModel
         return $this;
     }
 
+    public function isAutomaticBorgRepositoriesPruneEnabled(): ?bool
+    {
+        return $this->automaticBorgRepositoriesPruneEnabled;
+    }
+
+    public function setAutomaticBorgRepositoriesPruneEnabled(?bool $automaticBorgRepositoriesPruneEnabled): self
+    {
+        $this->automaticBorgRepositoriesPruneEnabled = $automaticBorgRepositoriesPruneEnabled;
+
+        return $this;
+    }
+
+    public function isPhpSessionSpreadEnabled(): ?bool
+    {
+        return $this->phpSessionSpreadEnabled;
+    }
+
+    public function setPhpSessionSpreadEnabled(?bool $phpSessionSpreadEnabled): self
+    {
+        $this->phpSessionSpreadEnabled = $phpSessionSpreadEnabled;
+
+        return $this;
+    }
+
     public function getDescription(): ?string
     {
         return $this->description;
@@ -276,6 +315,7 @@ class Cluster extends ClusterModel
             ->setGroups(Arr::get($data, 'groups', []))
             ->setUnixUsersHomeDirectory(Arr::get($data, 'unix_users_home_directory'))
             ->setPhpVersions(Arr::get($data, 'php_versions', []))
+            ->setPhpSettings(Arr::get($data, 'php_settings', []))
             ->setCustomPhpModulesNames(Arr::get($data, 'custom_php_modules_names', []))
             ->setPhpIoncubeEnabled(Arr::get($data, 'php_ioncube_enabled'))
             ->setNodejsVersions(Arr::get($data, 'nodejs_versions', []))
@@ -286,6 +326,8 @@ class Cluster extends ClusterModel
             ->setMalwareToolkitScansEnabled(Arr::get($data, 'malware_toolkit_scans_enabled'))
             ->setBubblewrapToolkitEnabled(Arr::get($data, 'bubblewrap_toolkit_enabled'))
             ->setSyncToolkitEnabled(Arr::get($data, 'sync_toolkit_enabled'))
+            ->setAutomaticBorgRepositoriesPruneEnabled(Arr::get($data, 'automatic_borg_repositories_prune_enabled'))
+            ->setPhpSessionSpreadEnabled(Arr::get($data, 'php_sessions_spread_enabled'))
             ->setDescription(Arr::get($data, 'description'))
             ->setId(Arr::get($data, 'id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -299,6 +341,7 @@ class Cluster extends ClusterModel
             'groups' => $this->getGroups(),
             'unix_users_home_directory' => $this->getUnixUsersHomeDirectory(),
             'php_versions' => $this->getPhpVersions(),
+            'php_settings' => $this->getPhpSettings(),
             'custom_php_modules_names' => $this->getCustomPhpModulesNames(),
             'php_ioncube_enabled' => $this->isPhpIoncubeEnabled(),
             'nodejs_versions' => $this->getNodejsVersions(),
@@ -309,6 +352,8 @@ class Cluster extends ClusterModel
             'malware_toolkit_scans_enabled' => $this->isMalwareToolkitScansEnabled(),
             'bubblewrap_toolkit_enabled' => $this->isBubblewrapToolkitEnabled(),
             'sync_toolkit_enabled' => $this->isSyncToolkitEnabled(),
+            'automatic_borg_repositories_prune_enabled' => $this->isAutomaticBorgRepositoriesPruneEnabled(),
+            'php_sessions_spread_enabled' => $this->isPhpSessionSpreadEnabled(),
             'description' => $this->getDescription(),
             'id' => $this->getId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/FirewallGroup.php
+++ b/src/Models/FirewallGroup.php
@@ -2,19 +2,15 @@
 
 namespace Cyberfusion\ClusterApi\Models;
 
-use Cyberfusion\ClusterApi\Enums\VirtualHostServerSoftwareName;
 use Cyberfusion\ClusterApi\Support\Arr;
 use Cyberfusion\ClusterApi\Support\Validator;
 
-class CustomConfigSnippet extends ClusterModel
+class FirewallGroup extends ClusterModel
 {
     private string $name;
-    private string $serverSoftwareName;
-    private ?bool $isDefault = null;
-    private ?string $contents = null;
-    private ?string $templateName = null;
-    private int $clusterId;
+    private array $ipNetworks = [];
     private ?int $id = null;
+    private ?int $clusterId = null;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
 
@@ -28,7 +24,7 @@ class CustomConfigSnippet extends ClusterModel
         Validator::value($name)
             ->minLength(1)
             ->maxLength(32)
-            ->pattern('^[a-z_]+$')
+            ->pattern('^[a-z0-9_]+$')
             ->validate();
 
         $this->name = $name;
@@ -36,54 +32,18 @@ class CustomConfigSnippet extends ClusterModel
         return $this;
     }
 
-    public function getServerSoftwareName(): string
+    public function getIpNetworks(): array
     {
-        return $this->serverSoftwareName;
+        return $this->ipNetworks;
     }
 
-    public function setServerSoftwareName(string $serverSoftwareName): self
+    public function setIpNetworks(array $ipNetworks): self
     {
-        Validator::value($serverSoftwareName)
-            ->valueIn(VirtualHostServerSoftwareName::AVAILABLE)
+        Validator::value($ipNetworks)
+            ->unique()
             ->validate();
 
-        $this->serverSoftwareName = $serverSoftwareName;
-
-        return $this;
-    }
-
-    public function isDefault(): ?bool
-    {
-        return $this->isDefault;
-    }
-
-    public function setIsDefault(?bool $isDefault): self
-    {
-        $this->isDefault = $isDefault;
-
-        return $this;
-    }
-
-    public function getContents(): ?string
-    {
-        return $this->contents;
-    }
-
-    public function setContents(?string $contents): self
-    {
-        $this->contents = $contents;
-
-        return $this;
-    }
-
-    public function getTemplateName(): ?string
-    {
-        return $this->templateName;
-    }
-
-    public function setTemplateName(?string $templateName): self
-    {
-        $this->templateName = $templateName;
+        $this->ipNetworks = $ipNetworks;
 
         return $this;
     }
@@ -140,9 +100,7 @@ class CustomConfigSnippet extends ClusterModel
     {
         return $this
             ->setName(Arr::get($data, 'name'))
-            ->setServerSoftwareName(Arr::get($data, 'server_software_name'))
-            ->setIsDefault(Arr::get($data, 'is_default'))
-            ->setContents(Arr::get($data, 'contents'))
+            ->setIpNetworks(Arr::get($data, 'ip_networks', []))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -153,10 +111,7 @@ class CustomConfigSnippet extends ClusterModel
     {
         return [
             'name' => $this->getName(),
-            'server_software_name' => $this->getServerSoftwareName(),
-            'is_default' => $this->isDefault(),
-            'contents' => $this->getContents(),
-            'template_name' => $this->getTemplateName(),
+            'ip_networks' => $this->getIpNetworks(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/UnixUser.php
+++ b/src/Models/UnixUser.php
@@ -9,7 +9,7 @@ use Cyberfusion\ClusterApi\Support\Validator;
 class UnixUser extends ClusterModel
 {
     private string $username;
-    private string $password;
+    private ?string $password = null;
     private ?string $homeDirectory = null;
     private ?string $sshDirectory = null;
     private ?string $description = null;
@@ -48,12 +48,13 @@ class UnixUser extends ClusterModel
         return $this->password;
     }
 
-    public function setPassword(string $password): self
+    public function setPassword(?string $password = null): self
     {
         Validator::value($password)
             ->minLength(24)
             ->maxLength(255)
             ->pattern('^[ -~]+$')
+            ->nullable()
             ->validate();
 
         $this->password = $password;


### PR DESCRIPTION
# Changes

Closes #60 

### Added

- Add Firewall Groups endpoint.
- Add the new Node groups.
- Add `php_sessions_spread_enabled`, `automatic_borg_repositories_prune_enabled` and `php_settings` properties to the `Cluster` model.
- Add `CustomPhpModuleName` enum, to easily see which extensions are available.
- Add `is_default` property to the `CustomConfigSnippet` model.

### Changed

- Allow underscores in the name of a custom config snippet instead of a dash.
- Allow `null` as password for UNIX users to limit to SSH key login only. 
- Update to [API version 1.185.3](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.185.3-2023-07-21).

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
