### PR TITLE
Add missing `load_balancer_health_checks_groups_pairs` property to th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).. Please note this changelog affects 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
+
+## [1.100.1]
+
+### Fixed
+
+- Add missing `load_balancer_health_checks_groups_pairs` property to the `Node` model.
 
 ## [1.100.0]
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.100.0';
+    private const VERSION = '1.100.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Models/Node.php
+++ b/src/Models/Node.php
@@ -2,6 +2,7 @@
 
 namespace Cyberfusion\ClusterApi\Models;
 
+use Cyberfusion\ClusterApi\Enums\NodeGroup;
 use Cyberfusion\ClusterApi\Support\Arr;
 use Cyberfusion\ClusterApi\Support\Validator;
 
@@ -10,6 +11,7 @@ class Node extends ClusterModel
     private string $hostname;
     private array $groups = [];
     private ?string $comment = null;
+    private array $loadBalancerHealthChecksGroupsPairs = [];
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -52,6 +54,24 @@ class Node extends ClusterModel
             ->validate();
 
         $this->comment = $comment;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, array<NodeGroup>>
+     */
+    public function getLoadBalancerHealthChecksGroupsPairs(): array
+    {
+        return $this->loadBalancerHealthChecksGroupsPairs;
+    }
+
+    /**
+     * @param array<string, array<NodeGroup>> $loadBalancerHealthChecksGroupsPairs
+     */
+    public function setLoadBalancerHealthChecksGroupsPairs(array $loadBalancerHealthChecksGroupsPairs): self
+    {
+        $this->loadBalancerHealthChecksGroupsPairs = $loadBalancerHealthChecksGroupsPairs;
 
         return $this;
     }
@@ -110,6 +130,7 @@ class Node extends ClusterModel
             ->setHostname(Arr::get($data, 'hostname'))
             ->setGroups(Arr::get($data, 'groups', []))
             ->setComment(Arr::get($data, 'comment'))
+            ->setLoadBalancerHealthChecksGroupsPairs(Arr::get($data, 'load_balancer_health_checks_groups_pairs', []))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -122,6 +143,7 @@ class Node extends ClusterModel
             'hostname' => $this->getHostname(),
             'groups' => $this->getGroups(),
             'comment' => $this->getComment(),
+            'load_balancer_health_checks_groups_pairs' => $this->getLoadBalancerHealthChecksGroupsPairs(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),


### PR DESCRIPTION
…e `Node` model

# Changes

### Fixed

- Add missing `load_balancer_health_checks_groups_pairs` property to the `Node` model.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
