### PR TITLE
Update to API version 1.187.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.101.0]
+
+### Added
+
+- Add `kernelcare_license_key`, `redis_password`, `redis_memory_limit`, `nodejs_version`, `mariadb_version`, `mariadb_cluster_name`, `mariadb_backup_interval`, `postgresql_version` and `postgresql_backup_interval` attributes to the `Cluster` model.
+- Add `optimizing_enabled` and `backups_enabled` attribute to the `Database` model.
+- Add `group_poperties` to the `Node` model.
+- Add `Tombstone` endpoint.
+- Add `ApiUsers` endpoint, which is just a basic endpoint that returns the raw data.
+- Add the `children` call to the `Clusters` endpoint, which is just a basic endpoint that returns the raw data.
+
+### Changed
+
+- Update to [API version 1.187.1](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.187.1-2023-08-02).
+
 ## [1.100.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.185.3** version of the API.
+This client was built for and tested on the **1.187.1** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.100.1';
+    private const VERSION = '1.101.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -2,20 +2,21 @@
 
 namespace Cyberfusion\ClusterApi;
 
+use Cyberfusion\ClusterApi\Contracts\Client as ClientContract;
 use Cyberfusion\ClusterApi\Endpoints\ApiUsers;
 use Cyberfusion\ClusterApi\Endpoints\Authentication;
 use Cyberfusion\ClusterApi\Endpoints\BasicAuthenticationRealms;
 use Cyberfusion\ClusterApi\Endpoints\BorgArchives;
 use Cyberfusion\ClusterApi\Endpoints\BorgRepositories;
-use Cyberfusion\ClusterApi\Endpoints\Certificates;
 use Cyberfusion\ClusterApi\Endpoints\CertificateManagers;
+use Cyberfusion\ClusterApi\Endpoints\Certificates;
 use Cyberfusion\ClusterApi\Endpoints\Clusters;
 use Cyberfusion\ClusterApi\Endpoints\Cmses;
 use Cyberfusion\ClusterApi\Endpoints\Crons;
 use Cyberfusion\ClusterApi\Endpoints\CustomConfigSnippets;
 use Cyberfusion\ClusterApi\Endpoints\Databases;
-use Cyberfusion\ClusterApi\Endpoints\DatabaseUsers;
 use Cyberfusion\ClusterApi\Endpoints\DatabaseUserGrants;
+use Cyberfusion\ClusterApi\Endpoints\DatabaseUsers;
 use Cyberfusion\ClusterApi\Endpoints\DomainRouters;
 use Cyberfusion\ClusterApi\Endpoints\FirewallGroups;
 use Cyberfusion\ClusterApi\Endpoints\FpmPools;
@@ -39,7 +40,6 @@ use Cyberfusion\ClusterApi\Endpoints\Tombstones;
 use Cyberfusion\ClusterApi\Endpoints\UnixUsers;
 use Cyberfusion\ClusterApi\Endpoints\UrlRedirects;
 use Cyberfusion\ClusterApi\Endpoints\VirtualHosts;
-use Cyberfusion\ClusterApi\Contracts\Client as ClientContract;
 
 class ClusterApi
 {

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -2,20 +2,20 @@
 
 namespace Cyberfusion\ClusterApi;
 
-use Cyberfusion\ClusterApi\Contracts\Client as ClientContract;
+use Cyberfusion\ClusterApi\Endpoints\ApiUsers;
 use Cyberfusion\ClusterApi\Endpoints\Authentication;
 use Cyberfusion\ClusterApi\Endpoints\BasicAuthenticationRealms;
 use Cyberfusion\ClusterApi\Endpoints\BorgArchives;
 use Cyberfusion\ClusterApi\Endpoints\BorgRepositories;
-use Cyberfusion\ClusterApi\Endpoints\CertificateManagers;
 use Cyberfusion\ClusterApi\Endpoints\Certificates;
+use Cyberfusion\ClusterApi\Endpoints\CertificateManagers;
 use Cyberfusion\ClusterApi\Endpoints\Clusters;
 use Cyberfusion\ClusterApi\Endpoints\Cmses;
 use Cyberfusion\ClusterApi\Endpoints\Crons;
 use Cyberfusion\ClusterApi\Endpoints\CustomConfigSnippets;
 use Cyberfusion\ClusterApi\Endpoints\Databases;
-use Cyberfusion\ClusterApi\Endpoints\DatabaseUserGrants;
 use Cyberfusion\ClusterApi\Endpoints\DatabaseUsers;
+use Cyberfusion\ClusterApi\Endpoints\DatabaseUserGrants;
 use Cyberfusion\ClusterApi\Endpoints\DomainRouters;
 use Cyberfusion\ClusterApi\Endpoints\FirewallGroups;
 use Cyberfusion\ClusterApi\Endpoints\FpmPools;
@@ -35,9 +35,11 @@ use Cyberfusion\ClusterApi\Endpoints\RedisInstances;
 use Cyberfusion\ClusterApi\Endpoints\RootSshKeys;
 use Cyberfusion\ClusterApi\Endpoints\SshKeys;
 use Cyberfusion\ClusterApi\Endpoints\TaskCollections;
+use Cyberfusion\ClusterApi\Endpoints\Tombstones;
 use Cyberfusion\ClusterApi\Endpoints\UnixUsers;
 use Cyberfusion\ClusterApi\Endpoints\UrlRedirects;
 use Cyberfusion\ClusterApi\Endpoints\VirtualHosts;
+use Cyberfusion\ClusterApi\Contracts\Client as ClientContract;
 
 class ClusterApi
 {
@@ -45,9 +47,19 @@ class ClusterApi
     {
     }
 
+    public function apiUsers(): ApiUsers
+    {
+        return new ApiUsers($this->client);
+    }
+
     public function authentication(): Authentication
     {
         return new Authentication($this->client);
+    }
+
+    public function basicAuthenticationRealms(): BasicAuthenticationRealms
+    {
+        return new BasicAuthenticationRealms($this->client);
     }
 
     public function borgArchives(): BorgArchives
@@ -90,11 +102,6 @@ class ClusterApi
         return new CustomConfigSnippets($this->client);
     }
 
-    public function basicAuthenticationRealms(): BasicAuthenticationRealms
-    {
-        return new BasicAuthenticationRealms($this->client);
-    }
-
     public function databases(): Databases
     {
         return new Databases($this->client);
@@ -108,6 +115,11 @@ class ClusterApi
     public function databaseUserGrants(): DatabaseUserGrants
     {
         return new DatabaseUserGrants($this->client);
+    }
+
+    public function domainRouters(): DomainRouters
+    {
+        return new DomainRouters($this->client);
     }
 
     public function firewallGroups(): FirewallGroups
@@ -125,6 +137,11 @@ class ClusterApi
         return new FtpUsers($this->client);
     }
 
+    public function health(): Health
+    {
+        return new Health($this->client);
+    }
+
     public function htpasswdFiles(): HtpasswdFiles
     {
         return new HtpasswdFiles($this->client);
@@ -133,11 +150,6 @@ class ClusterApi
     public function htpasswdUsers(): HtpasswdUsers
     {
         return new HtpasswdUsers($this->client);
-    }
-
-    public function health(): Health
-    {
-        return new Health($this->client);
     }
 
     public function logs(): Logs
@@ -185,19 +197,24 @@ class ClusterApi
         return new RedisInstances($this->client);
     }
 
-    public function sshKeys(): SshKeys
-    {
-        return new SshKeys($this->client);
-    }
-
     public function rootSshKeys(): RootSshKeys
     {
         return new RootSshKeys($this->client);
     }
 
+    public function sshKeys(): SshKeys
+    {
+        return new SshKeys($this->client);
+    }
+
     public function taskCollections(): TaskCollections
     {
         return new TaskCollections($this->client);
+    }
+
+    public function tombstones(): Tombstones
+    {
+        return new Tombstones($this->client);
     }
 
     public function unixUsers(): UnixUsers
@@ -208,11 +225,6 @@ class ClusterApi
     public function urlRedirects(): UrlRedirects
     {
         return new UrlRedirects($this->client);
-    }
-
-    public function domainRouters(): DomainRouters
-    {
-        return new DomainRouters($this->client);
     }
 
     public function virtualHosts(): VirtualHosts

--- a/src/Endpoints/ApiUsers.php
+++ b/src/Endpoints/ApiUsers.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Endpoints;
+
+use Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Cyberfusion\ClusterApi\Request;
+use Cyberfusion\ClusterApi\Response;
+
+class ApiUsers extends Endpoint
+{
+    /**
+     * @throws RequestException
+     */
+    public function clustersChildren(): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl('api-users/clusters-children');
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -65,6 +65,20 @@ class Clusters extends Endpoint
     /**
      * @throws RequestException
      */
+    public function children(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('clusters/%d/children', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+
+    /**
+     * @throws RequestException
+     */
     public function unixUsersHomeDirectoryUsages(
         int $id,
         DateTimeInterface $from,

--- a/src/Endpoints/Tombstones.php
+++ b/src/Endpoints/Tombstones.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Endpoints;
+
+use Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Cyberfusion\ClusterApi\Models\Tombstone;
+use Cyberfusion\ClusterApi\Request;
+use Cyberfusion\ClusterApi\Response;
+use Cyberfusion\ClusterApi\Support\ListFilter;
+
+class Tombstones extends Endpoint
+{
+    /**
+     * @throws RequestException
+     */
+    public function list(?ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('tombstones?%s', $filter->toQuery()));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'tombstones' => array_map(
+                fn (array $data) => (new Tombstone())->fromArray($data),
+                $response->getData()
+            ),
+        ]);
+    }
+}

--- a/src/Enums/ObjectModelName.php
+++ b/src/Enums/ObjectModelName.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Enums;
+
+class ObjectModelName
+{
+    public const BORG_ARCHIVE = 'BorgArchive';
+    public const BORG_REPOSITORY = 'BorgRepository';
+    public const CLUSTER = 'Cluster';
+    public const CMS = 'CMS';
+    public const FPM_POOL = 'FPMPool';
+    public const VIRTUAL_HOST = 'VirtualHost';
+    public const PASSENGER_APP = 'PassengerApp';
+    public const DATABASE = 'Database';
+    public const CERTIFICATE_MANAGER = 'CertificateManager';
+    public const BASIC_AUTHENTICATION_REALM = 'BasicAuthenticationRealm';
+    public const CRON = 'Cron';
+    public const DATABASE_USER = 'DatabaseUser';
+    public const DATABASE_USER_GRANT = 'DatabaseUserGrant';
+    public const HTPASSWD_FILE = 'HtpasswdFile';
+    public const HTPASSWD_USER = 'HtpasswdUser';
+    public const MAIL_ACCOUNT = 'MailAccount';
+    public const MAIL_ALIAS = 'MailAlias';
+    public const MAIL_DOMAIN = 'MailDomain';
+    public const NODE = 'Node';
+    public const REDIS_INSTANCE = 'RedisInstance';
+    public const DOMAIN_ROUTER = 'DomainRouter';
+    public const MAIL_HOSTNAME = 'MailHostname';
+    public const CERTIFICATE = 'Certificate';
+    public const ROOT_SSH_KEY = 'RootSSHKey';
+    public const SSH_KEY = 'SSHKey';
+    public const UNIX_USER = 'UNIXUser';
+    public const UNIX_USER_RABBIT_MQ_CREDENTIALS = 'UNIXUserRabbitMQCredentials';
+    public const HA_PROXY_LISTEN = 'HAProxyListen';
+    public const HA_PROXY_LISTEN_TO_NODE = 'HAProxyListenToNode';
+    public const URL_REDIRECT = 'URLRedirect';
+
+    public const AVAILABLE = [
+        self::BORG_ARCHIVE,
+        self::BORG_REPOSITORY,
+        self::CLUSTER,
+        self::CMS,
+        self::FPM_POOL,
+        self::VIRTUAL_HOST,
+        self::PASSENGER_APP,
+        self::DATABASE,
+        self::CERTIFICATE_MANAGER,
+        self::BASIC_AUTHENTICATION_REALM,
+        self::CRON,
+        self::DATABASE_USER,
+        self::DATABASE_USER_GRANT,
+        self::HTPASSWD_FILE,
+        self::HTPASSWD_USER,
+        self::MAIL_ACCOUNT,
+        self::MAIL_ALIAS,
+        self::MAIL_DOMAIN,
+        self::NODE,
+        self::REDIS_INSTANCE,
+        self::DOMAIN_ROUTER,
+        self::MAIL_HOSTNAME,
+        self::CERTIFICATE,
+        self::ROOT_SSH_KEY,
+        self::SSH_KEY,
+        self::UNIX_USER,
+        self::UNIX_USER_RABBIT_MQ_CREDENTIALS,
+        self::HA_PROXY_LISTEN,
+        self::HA_PROXY_LISTEN_TO_NODE,
+        self::URL_REDIRECT,
+    ];
+}

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -11,13 +11,22 @@ class Cluster extends ClusterModel
     private array $groups = [];
     private ?string $unixUsersHomeDirectory = null;
     private array $phpVersions = [];
+    private ?string $mariaDbVersion = null;
+    private ?string $mariaDbClusterName = null;
     private array $customPhpModulesNames = [];
     private array $phpSettings = [];
     private ?bool $phpIoncubeEnabled = null;
+    private ?string $kernelcareLicenseKey = null;
+    private ?string $redisPassword = null;
+    private ?int $redisMemoryLimit = null;
     private array $nodejsVersions = [];
+    private ?string $nodeJsVersion = null;
     private ?string $customerId = null;
     private ?bool $wordpressToolkitEnabled = null;
     private ?bool $databaseToolkitEnabled = null;
+    private ?int $mariaDbBackupInterval = null;
+    private ?string $postgreSQLVersion = null;
+    private ?int $postgreSQLBackupInterval = null;
     private ?bool $malwareToolkitEnabled = null;
     private ?bool $malwareToolkitScansEnabled = null;
     private ?bool $bubblewrapToolkitEnabled = null;
@@ -87,6 +96,30 @@ class Cluster extends ClusterModel
         return $this;
     }
 
+    public function getMariaDbVersion(): ?string
+    {
+        return $this->mariaDbVersion;
+    }
+
+    public function setMariaDbVersion(?string $mariaDbVersion): self
+    {
+        $this->mariaDbVersion = $mariaDbVersion;
+
+        return $this;
+    }
+
+    public function getMariaDbClusterName(): ?string
+    {
+        return $this->mariaDbClusterName;
+    }
+
+    public function setMariaDbClusterName(?string $mariaDbClusterName): self
+    {
+        $this->mariaDbClusterName = $mariaDbClusterName;
+
+        return $this;
+    }
+
     public function getCustomPhpModulesNames(): array
     {
         return $this->customPhpModulesNames;
@@ -123,6 +156,47 @@ class Cluster extends ClusterModel
         return $this;
     }
 
+    public function getKernelcareLicenseKey(): ?string
+    {
+        return $this->kernelcareLicenseKey;
+    }
+
+    public function setKernelcareLicenseKey(?string $kernelcareLicenseKey): self
+    {
+        $this->kernelcareLicenseKey = $kernelcareLicenseKey;
+
+        return $this;
+    }
+
+    public function getRedisPassword(): ?string
+    {
+        return $this->redisPassword;
+    }
+
+    public function setRedisPassword(?string $redisPassword): self
+    {
+        $this->redisPassword = $redisPassword;
+
+        return $this;
+    }
+
+    public function getRedisMemoryLimit(): ?int
+    {
+        return $this->redisMemoryLimit;
+    }
+
+    public function setRedisMemoryLimit(?int $redisMemoryLimit): self
+    {
+        Validator::value($redisMemoryLimit)
+            ->minAmount(0)
+            ->nullable()
+            ->validate();
+
+        $this->redisMemoryLimit = $redisMemoryLimit;
+
+        return $this;
+    }
+
     public function getNodejsVersions(): array
     {
         return $this->nodejsVersions;
@@ -136,6 +210,18 @@ class Cluster extends ClusterModel
             ->validate();
 
         $this->nodejsVersions = $nodejsVersions;
+
+        return $this;
+    }
+
+    public function getNodeJsVersion(): ?string
+    {
+        return $this->nodeJsVersion;
+    }
+
+    public function setNodeJsVersion(?string $nodeJsVersion): self
+    {
+        $this->nodeJsVersion = $nodeJsVersion;
 
         return $this;
     }
@@ -179,6 +265,52 @@ class Cluster extends ClusterModel
     {
         $this->databaseToolkitEnabled = $databaseToolkitEnabled;
 
+        return $this;
+    }
+
+    public function getMariaDbBackupInterval(): ?int
+    {
+        return $this->mariaDbBackupInterval;
+    }
+
+    public function setMariaDbBackupInterval(?int $mariaDbBackupInterval): self
+    {
+        Validator::value($mariaDbBackupInterval)
+            ->minAmount(4)
+            ->maxAmount(24)
+            ->nullable()
+            ->validate();
+
+        $this->mariaDbBackupInterval = $mariaDbBackupInterval;
+        return $this;
+    }
+
+    public function getPostgreSQLVersion(): ?string
+    {
+        return $this->postgreSQLVersion;
+    }
+
+    public function setPostgreSQLVersion(?string $postgreSQLVersion): self
+    {
+        $this->postgreSQLVersion = $postgreSQLVersion;
+
+        return $this;
+    }
+
+    public function getPostgreSQLBackupInterval(): ?int
+    {
+        return $this->postgreSQLBackupInterval;
+    }
+
+    public function setPostgreSQLBackupInterval(?int $postgreSQLBackupInterval): self
+    {
+        Validator::value($postgreSQLBackupInterval)
+            ->minAmount(4)
+            ->maxAmount(24)
+            ->nullable()
+            ->validate();
+
+        $this->postgreSQLBackupInterval = $postgreSQLBackupInterval;
         return $this;
     }
 
@@ -315,13 +447,22 @@ class Cluster extends ClusterModel
             ->setGroups(Arr::get($data, 'groups', []))
             ->setUnixUsersHomeDirectory(Arr::get($data, 'unix_users_home_directory'))
             ->setPhpVersions(Arr::get($data, 'php_versions', []))
+            ->setMariaDbVersion(Arr::get($data, 'mariadb_version'))
+            ->setMariaDbClusterName(Arr::get($data, 'mariadb_cluster_name'))
             ->setPhpSettings(Arr::get($data, 'php_settings', []))
             ->setCustomPhpModulesNames(Arr::get($data, 'custom_php_modules_names', []))
             ->setPhpIoncubeEnabled(Arr::get($data, 'php_ioncube_enabled'))
+            ->setKernelcareLicenseKey(Arr::get($data, 'kernelcare_license_key'))
+            ->setRedisPassword(Arr::get($data, 'redis_password'))
+            ->setRedisMemoryLimit(Arr::get($data, 'redis_memory_limit'))
             ->setNodejsVersions(Arr::get($data, 'nodejs_versions', []))
+            ->setNodejsVersion(Arr::get($data, 'nodejs_version'))
             ->setCustomerId(Arr::get($data, 'customer_id'))
             ->setWordpressToolkitEnabled(Arr::get($data, 'wordpress_toolkit_enabled'))
             ->setDatabaseToolkitEnabled(Arr::get($data, 'database_toolkit_enabled'))
+            ->setMariaDbBackupInterval(Arr::get($data, 'mariadb_backup_interval'))
+            ->setPostgreSQLVersion(Arr::get($data, 'postgresql_version'))
+            ->setPostgreSQLBackupInterval(Arr::get($data, 'postgresql_backup_interval'))
             ->setMalwareToolkitEnabled(Arr::get($data, 'malware_toolkit_enabled'))
             ->setMalwareToolkitScansEnabled(Arr::get($data, 'malware_toolkit_scans_enabled'))
             ->setBubblewrapToolkitEnabled(Arr::get($data, 'bubblewrap_toolkit_enabled'))
@@ -341,13 +482,22 @@ class Cluster extends ClusterModel
             'groups' => $this->getGroups(),
             'unix_users_home_directory' => $this->getUnixUsersHomeDirectory(),
             'php_versions' => $this->getPhpVersions(),
+            'mariadb_version' => $this->getMariaDbVersion(),
+            'mariadb_cluster_name' => $this->getMariaDbClusterName(),
             'php_settings' => $this->getPhpSettings(),
             'custom_php_modules_names' => $this->getCustomPhpModulesNames(),
             'php_ioncube_enabled' => $this->isPhpIoncubeEnabled(),
+            'kernelcare_license_key' => $this->getKernelcareLicenseKey(),
+            'redis_password' => $this->getRedisPassword(),
+            'redis_memory_limit' => $this->getRedisMemoryLimit(),
             'nodejs_versions' => $this->getNodejsVersions(),
+            'nodejs_version' => $this->getNodejsVersion(),
             'customer_id' => $this->getCustomerId(),
             'wordpress_toolkit_enabled' => $this->isWordpressToolkitEnabled(),
             'database_toolkit_enabled' => $this->isDatabaseToolkitEnabled(),
+            'mariadb_backup_interval' => $this->getMariaDbBackupInterval(),
+            'postgresql_version' => $this->getPostgreSQLVersion(),
+            'postgresql_backup_interval' => $this->getPostgreSQLBackupInterval(),
             'malware_toolkit_enabled' => $this->istMalwareToolkitEnabled(),
             'malware_toolkit_scans_enabled' => $this->isMalwareToolkitScansEnabled(),
             'bubblewrap_toolkit_enabled' => $this->isBubblewrapToolkitEnabled(),

--- a/src/Models/Database.php
+++ b/src/Models/Database.php
@@ -10,6 +10,8 @@ class Database extends ClusterModel
 {
     private string $name;
     private string $serverSoftwareName = DatabaseEngine::SERVER_SOFTWARE_MARIADB;
+    private ?bool $optimizingEnabled = null;
+    private ?bool $backupsEnabled = null;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -44,6 +46,30 @@ class Database extends ClusterModel
             ->validate();
 
         $this->serverSoftwareName = $serverSoftwareName;
+
+        return $this;
+    }
+
+    public function getOptimizingEnabled(): ?bool
+    {
+        return $this->optimizingEnabled;
+    }
+
+    public function setOptimizingEnabled(?bool $optimizingEnabled): self
+    {
+        $this->optimizingEnabled = $optimizingEnabled;
+
+        return $this;
+    }
+
+    public function getBackupsEnabled(): ?bool
+    {
+        return $this->backupsEnabled;
+    }
+
+    public function setBackupsEnabled(?bool $backupsEnabled): self
+    {
+        $this->backupsEnabled = $backupsEnabled;
 
         return $this;
     }
@@ -107,6 +133,8 @@ class Database extends ClusterModel
                     DatabaseEngine::SERVER_SOFTWARE_MARIADB
                 )
             )
+            ->setBackupsEnabled(Arr::get($data, 'backups_enabled'))
+            ->setOptimizingEnabled(Arr::get($data, 'optimizing_enabled'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -118,6 +146,8 @@ class Database extends ClusterModel
         return [
             'name' => $this->getName(),
             'server_software_name' => $this->getServerSoftwareName(),
+            'backups_enabled' => $this->getBackupsEnabled(),
+            'optimizing_enabled' => $this->getOptimizingEnabled(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/Node.php
+++ b/src/Models/Node.php
@@ -12,6 +12,7 @@ class Node extends ClusterModel
     private array $groups = [];
     private ?string $comment = null;
     private array $loadBalancerHealthChecksGroupsPairs = [];
+    private array $groupProperties = [];
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -76,6 +77,18 @@ class Node extends ClusterModel
         return $this;
     }
 
+    public function getGroupProperties(): array
+    {
+        return $this->groupProperties;
+    }
+
+    public function setGroupProperties(array $groupProperties): self
+    {
+        $this->groupProperties = $groupProperties;
+
+        return $this;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -131,6 +144,7 @@ class Node extends ClusterModel
             ->setGroups(Arr::get($data, 'groups', []))
             ->setComment(Arr::get($data, 'comment'))
             ->setLoadBalancerHealthChecksGroupsPairs(Arr::get($data, 'load_balancer_health_checks_groups_pairs', []))
+            ->setGroupProperties(Arr::get($data, 'group_properties', []))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -144,6 +158,7 @@ class Node extends ClusterModel
             'groups' => $this->getGroups(),
             'comment' => $this->getComment(),
             'load_balancer_health_checks_groups_pairs' => $this->getLoadBalancerHealthChecksGroupsPairs(),
+            'group_properties' => $this->getGroupProperties(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/Tombstone.php
+++ b/src/Models/Tombstone.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use Cyberfusion\ClusterApi\Enums\ObjectModelName;
+use Cyberfusion\ClusterApi\Support\Arr;
+use Cyberfusion\ClusterApi\Support\Validator;
+
+class Tombstone extends ClusterModel
+{
+    private mixed $data = null;
+    private string $objectId;
+    private string $objectModelName;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getData(): mixed
+    {
+        return $this->data;
+    }
+
+    public function setData(mixed $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function getObjectId(): string
+    {
+        return $this->objectId;
+    }
+
+    public function setObjectId(string $objectId): self
+    {
+        $this->objectId = $objectId;
+
+        return $this;
+    }
+
+    public function getObjectModelName(): string
+    {
+        return $this->objectModelName;
+    }
+
+    public function setObjectModelName(string $objectModelName): self
+    {
+        Validator::value($objectModelName)
+            ->valueIn(ObjectModelName::AVAILABLE)
+            ->validate();
+
+        $this->objectModelName = $objectModelName;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): self
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setData(Arr::get($data, 'data'))
+            ->setObjectId(Arr::get($data, 'object_id'))
+            ->setObjectModelName(Arr::get($data, 'object_model_name'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'data' => $this->getData(),
+            'object_id' => $this->getObjectId(),
+            'object_model_name' => $this->getObjectModelName(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}

--- a/src/Support/Validator.php
+++ b/src/Support/Validator.php
@@ -10,6 +10,8 @@ class Validator
     private const NULLABLE = 'nullable';
     private const MAX_LENGTH = 'length_max';
     private const MIN_LENGTH = 'length_min';
+    private const MIN_AMOUNT = 'amount_min';
+    private const MAX_AMOUNT = 'amount_max';
     private const PATTERN = 'pattern';
     private const VALUE_IN = 'in_list';
     private const VALUES_IN = 'part_of_list';
@@ -52,6 +54,18 @@ class Validator
     public function minLength(int $minLength): self
     {
         $this->validations[self::MIN_LENGTH] = $minLength;
+        return $this;
+    }
+
+    public function maxAmount(int $maxAmount): self
+    {
+        $this->validations[self::MAX_AMOUNT] = $maxAmount;
+        return $this;
+    }
+
+    public function minAmount(int $minAmount): self
+    {
+        $this->validations[self::MIN_AMOUNT] = $minAmount;
         return $this;
     }
 
@@ -125,6 +139,14 @@ class Validator
                 return
                     (is_string($value) && Str::length($value) >= $setting) ||
                     (is_array($value) && count($value) >= $setting);
+            case self::MAX_AMOUNT:
+                return
+                    (is_numeric($value) && $value <= $setting) ||
+                    (is_array($value) && max($value) <= $setting);
+            case self::MIN_AMOUNT:
+                return
+                    (is_numeric($value) && $value >= $setting) ||
+                    (is_array($value) && min($value) >= $setting);
             case self::PATTERN:
                 return is_string($value) && Str::doesMatch($value, sprintf('/%s/', $setting));
             case self::VALUE_IN:

--- a/tests/Support/ValidatorTest.php
+++ b/tests/Support/ValidatorTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ValidatorTest extends TestCase
 {
-    public function testSingleValueOnly()
+    public function testSingleValueOnly(): void
     {
         $result = Validator::value('test')
             ->validate();
@@ -20,14 +20,14 @@ class ValidatorTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testMultipleValuesOnly()
+    public function testMultipleValuesOnly(): void
     {
         $result = Validator::value(['foo', 'bar'])
             ->validate();
         $this->assertTrue($result);
     }
 
-    public function testNullable()
+    public function testNullable(): void
     {
         $result = Validator::value(null)
             ->nullable()
@@ -41,7 +41,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testNullableMultiple()
+    public function testNullableMultiple(): void
     {
         $result = Validator::value([null, null])
             ->each()
@@ -50,7 +50,7 @@ class ValidatorTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testMaxLength()
+    public function testMaxLength(): void
     {
         $result = Validator::value('test')
             ->maxLength(5)
@@ -68,7 +68,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testMaxLengthMultiple()
+    public function testMaxLengthMultiple(): void
     {
         $result = Validator::value(['foo', 'bar'])
             ->each()
@@ -89,7 +89,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testMinLength()
+    public function testMinLength(): void
     {
         $result = Validator::value('test')
             ->minLength(2)
@@ -107,7 +107,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testMinLengthMultiple()
+    public function testMinLengthMultiple(): void
     {
         $result = Validator::value(['foo', 'bar'])
             ->each()
@@ -128,7 +128,85 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testPattern()
+    public function testMaxAmount(): void
+    {
+        $result = Validator::value(100)
+            ->maxAmount(500)
+            ->validate();
+        $this->assertTrue($result);
+
+        $result = Validator::value([1, 2, 3, 4, 5])
+            ->maxAmount(10)
+            ->validate();
+        $this->assertTrue($result);
+
+        $this->expectException(ValidationException::class);
+        Validator::value(5)
+            ->maxAmount(2)
+            ->validate();
+    }
+
+    public function testMaxAmountMultiple(): void
+    {
+        $result = Validator::value([2, 5])
+            ->each()
+            ->maxAmount(10)
+            ->validate();
+        $this->assertTrue($result);
+
+        $result = Validator::value([[1, 2, 3, 4, 5], [6, 7, 8]])
+            ->each()
+            ->maxAmount(10)
+            ->validate();
+        $this->assertTrue($result);
+
+        $this->expectException(ValidationException::class);
+        Validator::value([2, 5])
+            ->each()
+            ->maxAmount(4)
+            ->validate();
+    }
+
+    public function testMinAmount(): void
+    {
+        $result = Validator::value(5)
+            ->minAmount(2)
+            ->validate();
+        $this->assertTrue($result);
+
+        $result = Validator::value([1, 2])
+            ->minAmount(0)
+            ->validate();
+        $this->assertTrue($result);
+
+        $this->expectException(ValidationException::class);
+        Validator::value(0)
+            ->minAmount(2)
+            ->validate();
+    }
+
+    public function testMinAmountMultiple(): void
+    {
+        $result = Validator::value([2, 5])
+            ->each()
+            ->minAmount(1)
+            ->validate();
+        $this->assertTrue($result);
+
+        $result = Validator::value([[1, 2], [3, 4, 5]])
+            ->each()
+            ->minAmount(1)
+            ->validate();
+        $this->assertTrue($result);
+
+        $this->expectException(ValidationException::class);
+        Validator::value([1, 2])
+            ->each()
+            ->minAmount(2)
+            ->validate();
+    }
+
+    public function testPattern(): void
     {
         $result = Validator::value('test')
             ->pattern('^[a-z]+$')
@@ -141,7 +219,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testPatternMultiple()
+    public function testPatternMultiple(): void
     {
         $result = Validator::value(['foo', 'bar'])
             ->each()
@@ -156,7 +234,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testValueIn()
+    public function testValueIn(): void
     {
         $result = Validator::value('test')
             ->valueIn(['test', 'foo', 'bar'])
@@ -169,7 +247,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testValueInMultiple()
+    public function testValueInMultiple(): void
     {
         $result = Validator::value(['test', 'foo'])
             ->each()
@@ -184,7 +262,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testValuesIn()
+    public function testValuesIn(): void
     {
         $result = Validator::value(['foo', 'bar'])
             ->valuesIn(['test', 'foo', 'bar'])
@@ -197,7 +275,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testValuesInMultiple()
+    public function testValuesInMultiple(): void
     {
         $result = Validator::value([['foo', 'bar'], ['test', 'bar']])
             ->each()
@@ -212,7 +290,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testUnique()
+    public function testUnique(): void
     {
         $result = Validator::value(['foo', 'bar'])
             ->unique()
@@ -225,7 +303,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testUniqueMultiple()
+    public function testUniqueMultiple(): void
     {
         $result = Validator::value([['foo', 'bar'], ['foo', 'bar']])
             ->each()
@@ -240,7 +318,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testIp()
+    public function testIp(): void
     {
         $result = Validator::value(['127.0.0.1', '192.168.1.1'])
             ->each()
@@ -255,7 +333,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testEmail()
+    public function testEmail(): void
     {
         $result = Validator::value('foo@bar.com')
             ->email()
@@ -268,7 +346,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testEmailMultiple()
+    public function testEmailMultiple(): void
     {
         $result = Validator::value(['foo@bar.com', 'bar@foo.com'])
             ->each()
@@ -283,7 +361,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testPath()
+    public function testPath(): void
     {
         $result = Validator::value('/home/test')
             ->path()
@@ -303,7 +381,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testPathMultiple()
+    public function testPathMultiple(): void
     {
         $result = Validator::value(['/home/test', '/home/foobar'])
             ->each()
@@ -318,7 +396,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testUuid()
+    public function testUuid(): void
     {
         $result = Validator::value(Str::uuid())
             ->uuid()
@@ -331,7 +409,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testUuidMultiple()
+    public function testUuidMultiple(): void
     {
         $result = Validator::value([Str::uuid(), Str::uuid()])
             ->each()
@@ -346,7 +424,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testEndsWith()
+    public function testEndsWith(): void
     {
         $result = Validator::value('test.js')
             ->endsWith('.js')
@@ -359,7 +437,7 @@ class ValidatorTest extends TestCase
             ->validate();
     }
 
-    public function testEndsWithMultiple()
+    public function testEndsWithMultiple(): void
     {
         $result = Validator::value(['test.js', 'app.js'])
             ->each()


### PR DESCRIPTION
Closes #68 

# Changes

### Added

- Add `kernelcare_license_key`, `redis_password`, `redis_memory_limit`, `nodejs_version`, `mariadb_version`, `mariadb_cluster_name`, `mariadb_backup_interval`, `postgresql_version` and `postgresql_backup_interval` attributes to the `Cluster` model.
- Add `optimizing_enabled` and `backups_enabled` attribute to the `Database` model.
- Add `group_poperties` to the `Node` model.
- Add `Tombstone` endpoint.
- Add `ApiUsers` endpoint, which is just a basic endpoint that returns the raw data.
- Add the `children` call to the `Clusters` endpoint, which is just a basic endpoint that returns the raw data.

### Changed

- Update to [API version 1.187.1](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.187.1-2023-08-02).

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
