### PR TITLE
Use proper name for groups_properties in the Node model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.101.1]
+
+### Fixed
+
+- Use proper name for `groups_properties` in the `Node` model.
+- Improve handling connection issues, for example when an invalid API url is provided, which resulted in an error in the `isUp` check.
+
 ## [1.101.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.101.0';
+    private const VERSION = '1.101.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 
@@ -75,9 +75,9 @@ class Client implements ClientContract
         }
 
         // Store and return if the API is up
-        return $response
+        return (bool) $response
             ->getData('health')
-            ->isUp();
+            ?->isUp();
     }
 
     /**

--- a/src/Models/Node.php
+++ b/src/Models/Node.php
@@ -12,7 +12,7 @@ class Node extends ClusterModel
     private array $groups = [];
     private ?string $comment = null;
     private array $loadBalancerHealthChecksGroupsPairs = [];
-    private array $groupProperties = [];
+    private array $groupsProperties = [];
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -77,14 +77,14 @@ class Node extends ClusterModel
         return $this;
     }
 
-    public function getGroupProperties(): array
+    public function getGroupsProperties(): array
     {
-        return $this->groupProperties;
+        return $this->groupsProperties;
     }
 
-    public function setGroupProperties(array $groupProperties): self
+    public function setGroupsProperties(array $groupsProperties): self
     {
-        $this->groupProperties = $groupProperties;
+        $this->groupsProperties = $groupsProperties;
 
         return $this;
     }
@@ -144,7 +144,7 @@ class Node extends ClusterModel
             ->setGroups(Arr::get($data, 'groups', []))
             ->setComment(Arr::get($data, 'comment'))
             ->setLoadBalancerHealthChecksGroupsPairs(Arr::get($data, 'load_balancer_health_checks_groups_pairs', []))
-            ->setGroupProperties(Arr::get($data, 'group_properties', []))
+            ->setGroupsProperties(Arr::get($data, 'groups_properties', []))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -158,7 +158,7 @@ class Node extends ClusterModel
             'groups' => $this->getGroups(),
             'comment' => $this->getComment(),
             'load_balancer_health_checks_groups_pairs' => $this->getLoadBalancerHealthChecksGroupsPairs(),
-            'group_properties' => $this->getGroupProperties(),
+            'groups_properties' => $this->getGroupsProperties(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),


### PR DESCRIPTION
# Changes

### Fixed

- Use proper name for `groups_properties` in the `Node` model.
- Improve handling connection issues, for example when an invalid API url is provided, which resulted in an error in the `isUp` check.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
