### PR TITLE
Fix the database create endpoint by providing the correct properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.101.2]
+
+### Fixed
+
+- Fix the database create endpoint by providing the correct properties.
+
 ## [1.101.1]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.101.1';
+    private const VERSION = '1.101.2';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -84,6 +84,8 @@ class Databases extends Endpoint
                     'name',
                     'server_software_name',
                     'cluster_id',
+                    'backups_enabled',
+                    'optimizing_enabled',
                 ])
             );
 


### PR DESCRIPTION
# Changes

Closes #72 

### Fixed

- Fix the database create endpoint by providing the correct properties.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
