### PR TITLE
Update to 1.198.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.102.0]
+
+### Added
+
+- CertificateManagers: Add restore endpoint.
+- Clusters: Add common properties endpoint.
+- Clusters: Add create endpoint.
+- Clusters: Add update endpoint.
+- Clusters: Add destroy endpoint.
+- Crons: Add `timeout_seconds`.
+- Databases: Add update endpoint.
+- HAProxy Listens: Add completely new endpoints.
+- HAProxy Listens To Nodes: Add completely new endpoints.
+- Nodes: Add create endpoint.
+- Nodes: Add update endpoint.
+- Nodes: Add destroy endpoint.
+- Nodes: Add `maldet` node group.
+- SecurityTxtPolicies: Add completely new endpoints.
+
+### Changed
+
+- Clusters: Change `customer_id` validation.
+- Update to [API version 1.198.2](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.198.2-2023-09-20).
+
+### Removed
+
+- Clusters: Remove `name` fields.
+- Nodes: Remove `hostname` field.
+- Nodes: Remove `Main` node group.
+
 ## [1.101.2]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.187.1** version of the API.
+This client was built for and tested on the **1.198.2** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.101.2';
+    private const VERSION = '1.102.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/CertificateManagers.php
+++ b/src/Endpoints/CertificateManagers.php
@@ -90,10 +90,8 @@ class CertificateManagers extends Endpoint
             return $response;
         }
 
-        $certificateManager = (new CertificateManager())->fromArray($response->getData());
-
         return $response->setData([
-            'certificateManager' => $certificateManager,
+            'certificateManager' => (new CertificateManager())->fromArray($response->getData()),
         ]);
     }
 
@@ -136,10 +134,29 @@ class CertificateManagers extends Endpoint
             return $response;
         }
 
-        $certificateManager = (new CertificateManager())->fromArray($response->getData());
+        return $response->setData([
+            'certificateManager' => (new CertificateManager())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function restore(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl(sprintf('certificate-managers/%d/restore', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
 
         return $response->setData([
-            'certificateManager' => $certificateManager,
+            'certificateManager' => (new CertificateManager())->fromArray($response->getData()),
         ]);
     }
 
@@ -173,10 +190,8 @@ class CertificateManagers extends Endpoint
             return $response;
         }
 
-        $taskCollection = (new TaskCollection())->fromArray($response->getData());
-
         return $response->setData([
-            'taskCollection' => $taskCollection,
+            'taskCollection' => (new TaskCollection())->fromArray($response->getData()),
         ]);
     }
 }

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -5,6 +5,7 @@ namespace Cyberfusion\ClusterApi\Endpoints;
 use Cyberfusion\ClusterApi\Enums\TimeUnit;
 use Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Cyberfusion\ClusterApi\Models\Cluster;
+use Cyberfusion\ClusterApi\Models\ClusterCommonProperties;
 use Cyberfusion\ClusterApi\Models\UnixUsersHomeDirectoryUsage;
 use Cyberfusion\ClusterApi\Request;
 use Cyberfusion\ClusterApi\Response;
@@ -60,6 +61,182 @@ class Clusters extends Endpoint
         return $response->setData([
             'cluster' => (new Cluster())->fromArray($response->getData()),
         ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function create(Cluster $cluster): Response
+    {
+        $this->validateRequired($cluster, 'create', [
+            'groups',
+            'unix_user_home_directory',
+            'php_versions',
+            'mariadb_version',
+            'nodejs_version',
+            'postgresql_version',
+            'mariadb_cluster_name',
+            'custom_php_modules_names',
+            'php_settings',
+            'php_ioncube_enabled',
+            'kernelcare_license_key',
+            'redis_password',
+            'redis_memory_limit',
+            'php_sessions_spread_enabled',
+            'nodejs_versions',
+            'description',
+            'wordpress_toolkit_enabled',
+            'automatic_borg_repositories_prune_enabled',
+            'malware_toolkit_enabled',
+            'sync_toolkit_enabled',
+            'bubblewrap_toolkit_enabled',
+            'malware_toolkit_scans_enabled',
+            'database_toolkit_enabled',
+            'mariadb_backup_interval',
+            'postgresql_backup_interval',
+            'customer_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('clusters')
+            ->setBody(
+                $this->filterFields($cluster->toArray(), [
+                    'groups',
+                    'unix_user_home_directory',
+                    'php_versions',
+                    'mariadb_version',
+                    'nodejs_version',
+                    'postgresql_version',
+                    'mariadb_cluster_name',
+                    'custom_php_modules_names',
+                    'php_settings',
+                    'php_ioncube_enabled',
+                    'kernelcare_license_key',
+                    'redis_password',
+                    'redis_memory_limit',
+                    'php_sessions_spread_enabled',
+                    'nodejs_versions',
+                    'description',
+                    'wordpress_toolkit_enabled',
+                    'automatic_borg_repositories_prune_enabled',
+                    'malware_toolkit_enabled',
+                    'sync_toolkit_enabled',
+                    'bubblewrap_toolkit_enabled',
+                    'malware_toolkit_scans_enabled',
+                    'database_toolkit_enabled',
+                    'mariadb_backup_interval',
+                    'postgresql_backup_interval',
+                    'customer_id',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'cluster' => (new Cluster())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function update(Cluster $cluster): Response
+    {
+        $this->validateRequired($cluster, 'update', [
+            'groups',
+            'unix_user_home_directory',
+            'php_versions',
+            'mariadb_version',
+            'nodejs_version',
+            'postgresql_version',
+            'mariadb_cluster_name',
+            'custom_php_modules_names',
+            'php_settings',
+            'php_ioncube_enabled',
+            'kernelcare_license_key',
+            'redis_password',
+            'redis_memory_limit',
+            'php_sessions_spread_enabled',
+            'nodejs_versions',
+            'description',
+            'wordpress_toolkit_enabled',
+            'automatic_borg_repositories_prune_enabled',
+            'malware_toolkit_enabled',
+            'sync_toolkit_enabled',
+            'bubblewrap_toolkit_enabled',
+            'malware_toolkit_scans_enabled',
+            'database_toolkit_enabled',
+            'mariadb_backup_interval',
+            'postgresql_backup_interval',
+            'customer_id',
+            'id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PUT)
+            ->setUrl(sprintf('clusters/%d', $cluster->getId()))
+            ->setBody(
+                $this->filterFields($cluster->toArray(), [
+                    'groups',
+                    'unix_user_home_directory',
+                    'php_versions',
+                    'mariadb_version',
+                    'nodejs_version',
+                    'postgresql_version',
+                    'mariadb_cluster_name',
+                    'custom_php_modules_names',
+                    'php_settings',
+                    'php_ioncube_enabled',
+                    'kernelcare_license_key',
+                    'redis_password',
+                    'redis_memory_limit',
+                    'php_sessions_spread_enabled',
+                    'nodejs_versions',
+                    'description',
+                    'wordpress_toolkit_enabled',
+                    'automatic_borg_repositories_prune_enabled',
+                    'malware_toolkit_enabled',
+                    'sync_toolkit_enabled',
+                    'bubblewrap_toolkit_enabled',
+                    'malware_toolkit_scans_enabled',
+                    'database_toolkit_enabled',
+                    'mariadb_backup_interval',
+                    'postgresql_backup_interval',
+                    'customer_id',
+                    'id',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'cluster' => (new Cluster())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('clusters/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
     }
 
     /**
@@ -127,6 +304,24 @@ class Clusters extends Endpoint
 
         return $response->setData([
             'publicKey' => $response->getData('public_key'),
+        ]);
+    }
+
+    public function commonProperties(): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl('clusters/common-properties');
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'commonProperties' => (new ClusterCommonProperties())->fromArray($response->getData()),
         ]);
     }
 }

--- a/src/Endpoints/Crons.php
+++ b/src/Endpoints/Crons.php
@@ -84,6 +84,7 @@ class Crons extends Endpoint
                     'node_id',
                     'error_count',
                     'random_delay_max_seconds',
+                    'timeout_seconds',
                     'locking_enabled',
                     'is_active',
                 ])
@@ -131,6 +132,7 @@ class Crons extends Endpoint
                     'node_id',
                     'error_count',
                     'random_delay_max_seconds',
+                    'timeout_seconds',
                     'locking_enabled',
                     'is_active',
                     'id',

--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -106,6 +106,46 @@ class Databases extends Endpoint
     /**
      * @throws RequestException
      */
+    public function update(Database $database): Response
+    {
+        $this->validateRequired($database, 'update', [
+            'name',
+            'server_software_name',
+            'optimizing_enabled',
+            'backups_enabled',
+            'id',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PUT)
+            ->setUrl(sprintf('databases/%d', $database->getId()))
+            ->setBody(
+                $this->filterFields($database->toArray(), [
+                    'name',
+                    'server_software_name',
+                    'optimizing_enabled',
+                    'backups_enabled',
+                    'id',
+                    'cluster_id',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'database' => (new Database())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
     public function delete(int $id): Response
     {
         $request = (new Request())

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -22,12 +22,12 @@ abstract class Endpoint
 
         $missing = [];
         foreach ($requiredAttributes as $requiredAttribute) {
-            $value = $modelFields[$requiredAttribute] ?? null;
-            if (is_null($value)) {
+            if (!array_key_exists($requiredAttribute, $modelFields)) {
                 $missing[] = $requiredAttribute;
                 continue;
             }
 
+            $value = $modelFields[$requiredAttribute] ?? null;
             if (is_string($value) && trim($value) === '') {
                 $missing[] = $requiredAttribute;
             }

--- a/src/Endpoints/HAProxyListens.php
+++ b/src/Endpoints/HAProxyListens.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Endpoints;
+
+use Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Cyberfusion\ClusterApi\Models\HAProxyListen;
+use Cyberfusion\ClusterApi\Request;
+use Cyberfusion\ClusterApi\Response;
+use Cyberfusion\ClusterApi\Support\ListFilter;
+
+class HAProxyListens extends Endpoint
+{
+    /**
+     * @throws RequestException
+     */
+    public function list(?ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('haproxy-listens?%s', $filter->toQuery()));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'haProxyListens' => array_map(
+                fn (array $data) => (new HAProxyListen())->fromArray($data),
+                $response->getData()
+            ),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('haproxy-listens/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'haProxyListen' => (new HAProxyListen())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function create(HAProxyListen $haProxyListen): Response
+    {
+        $this->validateRequired($haProxyListen, 'create', [
+            'name',
+            'nodes_group',
+            'port',
+            'socket_path',
+            'destination_cluster_id',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('haproxy-listens')
+            ->setBody(
+                $this->filterFields($haProxyListen->toArray(), [
+                    'name',
+                    'nodes_group',
+                    'port',
+                    'socket_path',
+                    'destination_cluster_id',
+                    'cluster_id',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'haProxyListens' => (new HAProxyListen())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('haproxy-listens/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Endpoints/HAProxyListensToNodes.php
+++ b/src/Endpoints/HAProxyListensToNodes.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Endpoints;
+
+use Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Cyberfusion\ClusterApi\Models\HAProxyListenToNode;
+use Cyberfusion\ClusterApi\Request;
+use Cyberfusion\ClusterApi\Response;
+use Cyberfusion\ClusterApi\Support\ListFilter;
+
+class HAProxyListensToNodes extends Endpoint
+{
+    /**
+     * @throws RequestException
+     */
+    public function list(?ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = HAProxyListenToNode::listFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('haproxy-listens-to-nodes?%s', $filter->toQuery()));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'HAProxyListensToNodes' => array_map(
+                fn (array $data) => (new HAProxyListenToNode())->fromArray($data),
+                $response->getData()
+            ),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('haproxy-listens-to-nodes/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'haProxyListenToNode' => (new HAProxyListenToNode())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function create(HAProxyListenToNode $haProxyListenToNode): Response
+    {
+        $this->validateRequired($haProxyListenToNode, 'create', [
+            'haproxy_listen_id',
+            'node_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('haproxy-listens-to-nodes')
+            ->setBody(
+                $this->filterFields($haProxyListenToNode->toArray(), [
+                    'haproxy_listen_id',
+                    'node_id',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'haProxyListenToNode' => (new HAProxyListenToNode())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('haproxy-listens-to-nodes/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Endpoints/SecurityTxtPolicies.php
+++ b/src/Endpoints/SecurityTxtPolicies.php
@@ -3,12 +3,12 @@
 namespace Cyberfusion\ClusterApi\Endpoints;
 
 use Cyberfusion\ClusterApi\Exceptions\RequestException;
-use Cyberfusion\ClusterApi\Models\Node;
+use Cyberfusion\ClusterApi\Models\SecurityTxtPolicy;
 use Cyberfusion\ClusterApi\Request;
 use Cyberfusion\ClusterApi\Response;
 use Cyberfusion\ClusterApi\Support\ListFilter;
 
-class Nodes extends Endpoint
+class SecurityTxtPolicies extends Endpoint
 {
     /**
      * @throws RequestException
@@ -21,7 +21,7 @@ class Nodes extends Endpoint
 
         $request = (new Request())
             ->setMethod(Request::METHOD_GET)
-            ->setUrl(sprintf('nodes?%s', $filter->toQuery()));
+            ->setUrl(sprintf('security-txt-policies?%s', $filter->toQuery()));
 
         $response = $this
             ->client
@@ -31,8 +31,8 @@ class Nodes extends Endpoint
         }
 
         return $response->setData([
-            'nodes' => array_map(
-                fn (array $data) => (new Node())->fromArray($data),
+            'securityTxtPolicies' => array_map(
+                fn (array $data) => (new SecurityTxtPolicy())->fromArray($data),
                 $response->getData()
             ),
         ]);
@@ -45,7 +45,7 @@ class Nodes extends Endpoint
     {
         $request = (new Request())
             ->setMethod(Request::METHOD_GET)
-            ->setUrl(sprintf('nodes/%d', $id));
+            ->setUrl(sprintf('security-txt-policies/%d', $id));
 
         $response = $this
             ->client
@@ -55,32 +55,40 @@ class Nodes extends Endpoint
         }
 
         return $response->setData([
-            'node' => (new Node())->fromArray($response->getData()),
+            'securityTxtPolicy' => (new SecurityTxtPolicy())->fromArray($response->getData()),
         ]);
     }
 
     /**
      * @throws RequestException
      */
-    public function create(Node $node): Response
+    public function create(SecurityTxtPolicy $securityTxtPolicy): Response
     {
-        $this->validateRequired($node, 'create', [
-            'groups',
-            'comment',
-            'load_balancer_health_checks_groups_pairs',
-            'groups_properties',
+        $this->validateRequired($securityTxtPolicy, 'create', [
+            'expires_timestamp',
+            'email_contacts',
+            'url_contacts',
+            'encryption_key_urls',
+            'acknowledgment_urls',
+            'policy_urls',
+            'opening_urls',
+            'preferred_languages',
             'cluster_id',
         ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
-            ->setUrl('nodes')
+            ->setUrl('security-txt-policies')
             ->setBody(
-                $this->filterFields($node->toArray(), [
-                    'groups',
-                    'comment',
-                    'load_balancer_health_checks_groups_pairs',
-                    'groups_properties',
+                $this->filterFields($securityTxtPolicy->toArray(), [
+                    'expires_timestamp',
+                    'email_contacts',
+                    'url_contacts',
+                    'encryption_key_urls',
+                    'acknowledgment_urls',
+                    'policy_urls',
+                    'opening_urls',
+                    'preferred_languages',
                     'cluster_id',
                 ])
             );
@@ -93,33 +101,41 @@ class Nodes extends Endpoint
         }
 
         return $response->setData([
-            'node' => (new Node())->fromArray($response->getData()),
+            'securityTxtPolicy' => (new SecurityTxtPolicy())->fromArray($response->getData()),
         ]);
     }
 
     /**
      * @throws RequestException
      */
-    public function update(Node $node): Response
+    public function update(SecurityTxtPolicy $securityTxtPolicy): Response
     {
-        $this->validateRequired($node, 'update', [
-            'groups',
-            'comment',
-            'load_balancer_health_checks_groups_pairs',
-            'groups_properties',
+        $this->validateRequired($securityTxtPolicy, 'update', [
+            'expires_timestamp',
+            'email_contacts',
+            'url_contacts',
+            'encryption_key_urls',
+            'acknowledgment_urls',
+            'policy_urls',
+            'opening_urls',
+            'preferred_languages',
             'cluster_id',
             'id',
         ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('nodes/%d', $node->getId()))
+            ->setUrl(sprintf('security-txt-policies/%d', $securityTxtPolicy->getId()))
             ->setBody(
-                $this->filterFields($node->toArray(), [
-                    'groups',
-                    'comment',
-                    'load_balancer_health_checks_groups_pairs',
-                    'groups_properties',
+                $this->filterFields($securityTxtPolicy->toArray(), [
+                    'expires_timestamp',
+                    'email_contacts',
+                    'url_contacts',
+                    'encryption_key_urls',
+                    'acknowledgment_urls',
+                    'policy_urls',
+                    'opening_urls',
+                    'preferred_languages',
                     'cluster_id',
                     'id',
                 ])
@@ -133,7 +149,7 @@ class Nodes extends Endpoint
         }
 
         return $response->setData([
-            'node' => (new Node())->fromArray($response->getData()),
+            'securityTxtPolicy' => (new SecurityTxtPolicy())->fromArray($response->getData()),
         ]);
     }
 
@@ -144,7 +160,7 @@ class Nodes extends Endpoint
     {
         $request = (new Request())
             ->setMethod(Request::METHOD_DELETE)
-            ->setUrl(sprintf('nodes/%d', $id));
+            ->setUrl(sprintf('security-txt-policies/%d', $id));
 
         return $this
             ->client

--- a/src/Enums/NodeGroup.php
+++ b/src/Enums/NodeGroup.php
@@ -17,7 +17,7 @@ class NodeGroup
     public const IMAGE_MAGICK = 'ImageMagick';
     public const KERNEL_CARE = 'KernelCare';
     public const LIBRE_OFFICE = 'LibreOffice';
-    public const MAIN = 'Main';
+    public const MALDET = 'maldet';
     public const MARIADB = 'MariaDB';
     public const NGINX = 'nginx';
     public const PASSENGER = 'Passenger';

--- a/src/Models/CertificateManager.php
+++ b/src/Models/CertificateManager.php
@@ -18,6 +18,7 @@ class CertificateManager extends ClusterModel
     private ?string $lastRequestTaskCollectionUuid = null;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
+    private ?string $deletedAt = null;
 
     public function getMainCommonName(): ?string
     {
@@ -147,6 +148,17 @@ class CertificateManager extends ClusterModel
         return $this;
     }
 
+    public function getDeletedAt(): ?string
+    {
+        return $this->deletedAt;
+    }
+
+    public function setDeletedAt(?string $deletedAt): self
+    {
+        $this->deletedAt = $deletedAt;
+        return $this;
+    }
+
     public function fromArray(array $data): self
     {
         return $this
@@ -159,7 +171,8 @@ class CertificateManager extends ClusterModel
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
-            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+            ->setUpdatedAt(Arr::get($data, 'updated_at'))
+            ->setDeletedAt(Arr::get($data, 'deleted_at'));
     }
 
     public function toArray(): array
@@ -175,6 +188,7 @@ class CertificateManager extends ClusterModel
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),
             'updated_at' => $this->getUpdatedAt(),
+            'deleted_at' => $this->getDeletedAt(),
         ];
     }
 }

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -21,7 +21,7 @@ class Cluster extends ClusterModel
     private ?int $redisMemoryLimit = null;
     private array $nodejsVersions = [];
     private ?string $nodeJsVersion = null;
-    private ?string $customerId = null;
+    private ?int $customerId = null;
     private ?bool $wordpressToolkitEnabled = null;
     private ?bool $databaseToolkitEnabled = null;
     private ?int $mariaDbBackupInterval = null;
@@ -226,17 +226,17 @@ class Cluster extends ClusterModel
         return $this;
     }
 
-    public function getCustomerId(): ?string
+    public function getCustomerId(): ?int
     {
         return $this->customerId;
     }
 
-    public function setCustomerId(?string $customerId): self
+    public function setCustomerId(?int $customerId): self
     {
         Validator::value($customerId)
             ->nullable()
-            ->maxLength(6)
-            ->pattern('^[A-Z0-9]+$')
+            ->minAmount(0)
+            ->pattern('^[0-9]+$')
             ->validate();
 
         $this->customerId = $customerId;

--- a/src/Models/ClusterCommonProperties.php
+++ b/src/Models/ClusterCommonProperties.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use Cyberfusion\ClusterApi\Support\Arr;
+use Cyberfusion\ClusterApi\Support\Validator;
+
+class ClusterCommonProperties extends ClusterModel
+{
+    private string $imapHostname;
+    private int $imapPort;
+    private string $imapEncryption;
+    private string $smtpHostname;
+    private int $smtpPort;
+    private string $smtpEncryption;
+    private string $pop3Hostname;
+    private int $pop3Port;
+    private string $pop3Encryption;
+    private string $phpmyadminUrl;
+
+    public function getImapHostname(): string
+    {
+        return $this->imapHostname;
+    }
+
+    public function setImapHostname(string $imapHostname): self
+    {
+        $this->imapHostname = $imapHostname;
+        return $this;
+    }
+
+    public function getImapPort(): int
+    {
+        return $this->imapPort;
+    }
+
+    public function setImapPort(int $imapPort): self
+    {
+        Validator::value($imapPort)
+            ->minAmount(0)
+            ->maxAmount(65535)
+            ->validate();
+
+        $this->imapPort = $imapPort;
+        return $this;
+    }
+
+    public function getImapEncryption(): string
+    {
+        return $this->imapEncryption;
+    }
+
+    public function setImapEncryption(string $imapEncryption): self
+    {
+        $this->imapEncryption = $imapEncryption;
+        return $this;
+    }
+
+    public function getSmtpHostname(): string
+    {
+        return $this->smtpHostname;
+    }
+
+    public function setSmtpHostname(string $smtpHostname): self
+    {
+        $this->smtpHostname = $smtpHostname;
+        return $this;
+    }
+
+    public function getSmtpPort(): int
+    {
+        return $this->smtpPort;
+    }
+
+    public function setSmtpPort(int $smtpPort): self
+    {
+        Validator::value($smtpPort)
+            ->minAmount(0)
+            ->maxAmount(65535)
+            ->validate();
+
+        $this->smtpPort = $smtpPort;
+        return $this;
+    }
+
+    public function getSmtpEncryption(): string
+    {
+        return $this->smtpEncryption;
+    }
+
+    public function setSmtpEncryption(string $smtpEncryption): self
+    {
+        $this->smtpEncryption = $smtpEncryption;
+        return $this;
+    }
+
+    public function getPop3Hostname(): string
+    {
+        return $this->pop3Hostname;
+    }
+
+    public function setPop3Hostname(string $pop3Hostname): self
+    {
+        $this->pop3Hostname = $pop3Hostname;
+        return $this;
+    }
+
+    public function getPop3Port(): int
+    {
+        return $this->pop3Port;
+    }
+
+    public function setPop3Port(int $pop3Port): self
+    {
+        Validator::value($pop3Port)
+            ->minAmount(0)
+            ->maxAmount(65535)
+            ->validate();
+
+        $this->pop3Port = $pop3Port;
+        return $this;
+    }
+
+    public function getPop3Encryption(): string
+    {
+        return $this->pop3Encryption;
+    }
+
+    public function setPop3Encryption(string $pop3Encryption): self
+    {
+        $this->pop3Encryption = $pop3Encryption;
+        return $this;
+    }
+
+    public function getPhpmyadminUrl(): string
+    {
+        return $this->phpmyadminUrl;
+    }
+
+    public function setPhpmyadminUrl(string $phpmyadminUrl): self
+    {
+        $this->phpmyadminUrl = $phpmyadminUrl;
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setImapHostname(Arr::get($data, 'imap_hostname'))
+            ->setImapPort(Arr::get($data, 'imap_port'))
+            ->setImapEncryption(Arr::get($data, 'imap_encryption'))
+            ->setSmtpHostname(Arr::get($data, 'smtp_hostname'))
+            ->setSmtpPort(Arr::get($data, 'smtp_port'))
+            ->setSmtpEncryption(Arr::get($data, 'smtp_encryption'))
+            ->setPop3Hostname(Arr::get($data, 'pop3_hostname'))
+            ->setPop3Port(Arr::get($data, 'pop3_port'))
+            ->setPop3Encryption(Arr::get($data, 'pop3_encryption'))
+            ->setPhpmyadminUrl(Arr::get($data, 'phpmyadmin_url'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'imap_hostname' => $this->imapHostname,
+            'imap_port' => $this->imapPort,
+            'imap_encryption' => $this->imapEncryption,
+            'smtp_hostname' => $this->smtpHostname,
+            'smtp_port' => $this->smtpPort,
+            'smtp_encryption' => $this->smtpEncryption,
+            'pop3_hostname' => $this->pop3Hostname,
+            'pop3_port' => $this->pop3Port,
+            'pop3_encryption' => $this->pop3Encryption,
+            'phpmyadmin_url' => $this->phpmyadminUrl,
+        ];
+    }
+}

--- a/src/Models/Cron.php
+++ b/src/Models/Cron.php
@@ -17,6 +17,7 @@ class Cron extends ClusterModel
     private int $randomDelayMaxSeconds = 10;
     private bool $lockingEnabled = true;
     private bool $isActive = true;
+    private ?int $timeoutSeconds = null;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -133,6 +134,23 @@ class Cron extends ClusterModel
         return $this;
     }
 
+    public function getTimeoutSeconds(): ?int
+    {
+        return $this->timeoutSeconds;
+    }
+
+    public function setTimeoutSeconds(?int $timeoutSeconds): self
+    {
+        Validator::value($timeoutSeconds)
+            ->minAmount(0)
+            ->nullable()
+            ->validate();
+
+        $this->timeoutSeconds = $timeoutSeconds;
+
+        return $this;
+    }
+
     public function isLockingEnabled(): bool
     {
         return $this->lockingEnabled;
@@ -216,6 +234,7 @@ class Cron extends ClusterModel
             ->setNodeId(Arr::get($data, 'node_id'))
             ->setErrorCount(Arr::get($data, 'error_count'))
             ->setRandomDelayMaxSeconds(Arr::get($data, 'random_delay_max_seconds'))
+            ->setTimeoutSeconds(Arr::get($data, 'timeout_seconds'))
             ->setLockingEnabled(Arr::get($data, 'locking_enabled'))
             ->setIsActive(Arr::get($data, 'is_active'))
             ->setId(Arr::get($data, 'id'))
@@ -235,6 +254,7 @@ class Cron extends ClusterModel
             'node_id' => $this->getNodeId(),
             'error_count' => $this->getErrorCount(),
             'random_delay_max_seconds' => $this->getRandomDelayMaxSeconds(),
+            'timeout_seconds' => $this->getTimeoutSeconds(),
             'locking_enabled' => $this->isLockingEnabled(),
             'is_active' => $this->isActive(),
             'id' => $this->getId(),

--- a/src/Models/HAProxyListen.php
+++ b/src/Models/HAProxyListen.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use Cyberfusion\ClusterApi\Enums\NodeGroup;
+use Cyberfusion\ClusterApi\Exceptions\ValidationException;
+use Cyberfusion\ClusterApi\Support\Arr;
+use Cyberfusion\ClusterApi\Support\Validator;
+
+class HAProxyListen extends ClusterModel
+{
+    private string $name;
+
+    private string $nodesGroup;
+
+    private ?int $port = null;
+
+    private ?string $socketPath = null;
+
+    private int $destinationClusterId;
+
+    private int $clusterId;
+
+    private ?int $id = null;
+
+    private ?string $createdAt = null;
+
+    private ?string $updatedAt = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        Validator::value($name)
+            ->minLength(1)
+            ->maxLength(64)
+            ->pattern('^[a-z_]+$')
+            ->validate();
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getNodesGroup(): string
+    {
+        return $this->nodesGroup;
+    }
+
+    public function setNodesGroup(string $nodesGroup): self
+    {
+        Validator::value($nodesGroup)
+            ->valueIn([
+                NodeGroup::ADMIN,
+                NodeGroup::APACHE,
+                NodeGroup::NGINX,
+                NodeGroup::DOVECOT,
+                NodeGroup::MARIADB,
+                NodeGroup::POSTGRESQL,
+                NodeGroup::MALDET,
+                NodeGroup::PHP,
+                NodeGroup::PASSENGER,
+                NodeGroup::BORG,
+                NodeGroup::FAST_REDIRECT,
+                NodeGroup::REDIS,
+                'HAProxy',
+            ])
+            ->validate();
+
+        $this->nodesGroup = $nodesGroup;
+
+        return $this;
+    }
+
+    public function getPort(): ?int
+    {
+        return $this->port;
+    }
+
+    public function setPort(int $port = null): self
+    {
+        Validator::value($port)
+            ->nullable()
+            ->validate();
+        if (!is_null($port) && ($port < 3306 || $port > 5432)) {
+            ValidationException::validationFailed([
+                sprintf(
+                    'port must be between 3306 and 5432, %d given',
+                    $port
+                ),
+            ]);
+        }
+
+        $this->port = $port;
+
+        return $this;
+    }
+
+    public function getSocketPath(): ?string
+    {
+        return $this->socketPath;
+    }
+
+    public function setSocketPath(?string $socketPath): self
+    {
+        $this->socketPath = $socketPath;
+
+        return $this;
+    }
+
+    public function getDestinationClusterId(): int
+    {
+        return $this->destinationClusterId;
+    }
+
+    public function setDestinationClusterId(int $destinationClusterId): self
+    {
+        $this->destinationClusterId = $destinationClusterId;
+
+        return $this;
+    }
+
+    public function getClusterId(): int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(int $clusterId): self
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setNodesGroup(Arr::get($data, 'nodes_group'))
+            ->setPort(Arr::get($data, 'port'))
+            ->setSocketPath(Arr::get($data, 'socket_path'))
+            ->setDestinationClusterId(Arr::get($data, 'destination_cluster_id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->getName(),
+            'nodes_group' => $this->getNodesGroup(),
+            'port' => $this->getPort(),
+            'socket_path' => $this->getSocketPath(),
+            'destination_cluster_id' => $this->getDestinationClusterId(),
+            'cluster_id' => $this->getClusterId(),
+            'id' => $this->getId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}

--- a/src/Models/HAProxyListenToNode.php
+++ b/src/Models/HAProxyListenToNode.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use Cyberfusion\ClusterApi\Support\Arr;
+
+class HAProxyListenToNode extends ClusterModel
+{
+    private int $haProxyListenId;
+
+    private int $nodeId;
+
+    private int $clusterId;
+
+    private ?int $id = null;
+
+    private ?string $createdAt = null;
+
+    private ?string $updatedAt = null;
+
+    public function getHaProxyListenId(): int
+    {
+        return $this->haProxyListenId;
+    }
+
+    public function setHaProxyListenId(int $haProxyListenId): self
+    {
+        $this->haProxyListenId = $haProxyListenId;
+
+        return $this;
+    }
+
+    public function getNodeId(): int
+    {
+        return $this->nodeId;
+    }
+
+    public function setNodeId(int $nodeId): self
+    {
+        $this->nodeId = $nodeId;
+
+        return $this;
+    }
+
+    public function getClusterId(): int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(int $clusterId): self
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setHaProxyListenId(Arr::get($data, 'ha_proxy_listen_id'))
+            ->setNodeId(Arr::get($data, 'node_id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'haproxy_listen_id' => $this->getHaProxyListenId(),
+            'node_id' => $this->getNodeId(),
+            'cluster_id' => $this->getClusterId(),
+            'id' => $this->getId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}

--- a/src/Models/Node.php
+++ b/src/Models/Node.php
@@ -8,7 +8,6 @@ use Cyberfusion\ClusterApi\Support\Validator;
 
 class Node extends ClusterModel
 {
-    private string $hostname;
     private array $groups = [];
     private ?string $comment = null;
     private array $loadBalancerHealthChecksGroupsPairs = [];
@@ -17,18 +16,6 @@ class Node extends ClusterModel
     private ?int $clusterId = null;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
-
-    public function getHostname(): string
-    {
-        return $this->hostname;
-    }
-
-    public function setHostname(string $hostname): self
-    {
-        $this->hostname = $hostname;
-
-        return $this;
-    }
 
     public function getGroups(): ?array
     {
@@ -140,7 +127,6 @@ class Node extends ClusterModel
     public function fromArray(array $data): self
     {
         return $this
-            ->setHostname(Arr::get($data, 'hostname'))
             ->setGroups(Arr::get($data, 'groups', []))
             ->setComment(Arr::get($data, 'comment'))
             ->setLoadBalancerHealthChecksGroupsPairs(Arr::get($data, 'load_balancer_health_checks_groups_pairs', []))
@@ -154,7 +140,6 @@ class Node extends ClusterModel
     public function toArray(): array
     {
         return [
-            'hostname' => $this->getHostname(),
             'groups' => $this->getGroups(),
             'comment' => $this->getComment(),
             'load_balancer_health_checks_groups_pairs' => $this->getLoadBalancerHealthChecksGroupsPairs(),

--- a/src/Models/SecurityTxtPolicy.php
+++ b/src/Models/SecurityTxtPolicy.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use Cyberfusion\ClusterApi\Support\Arr;
+use Cyberfusion\ClusterApi\Support\Validator;
+
+class SecurityTxtPolicy extends ClusterModel
+{
+    private string $expiresTimestamp;
+    private array $emailContacts = [];
+    private array $urlContacts = [];
+    private array $encryptingKeyUrls = [];
+    private array $acknowledgementUrls = [];
+    private array $policyUrls = [];
+    private array $openingUrls = [];
+    private array $preferredLanguages = [];
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getExpiresTimestamp(): string
+    {
+        return $this->expiresTimestamp;
+    }
+
+    public function setExpiresTimestamp(string $expiresTimestamp): self
+    {
+        $this->expiresTimestamp = $expiresTimestamp;
+        return $this;
+    }
+
+    public function getEmailContacts(): array
+    {
+        return $this->emailContacts;
+    }
+
+    public function setEmailContacts(array $emailContacts): self
+    {
+        Validator::value($emailContacts)
+            ->unique()
+            ->validate();
+
+        $this->emailContacts = $emailContacts;
+        return $this;
+    }
+
+    public function getUrlContacts(): array
+    {
+        return $this->urlContacts;
+    }
+
+    public function setUrlContacts(array $urlContacts): self
+    {
+        Validator::value($urlContacts)
+            ->unique()
+            ->validate();
+
+        $this->urlContacts = $urlContacts;
+        return $this;
+    }
+
+    public function getEncryptingKeyUrls(): array
+    {
+        return $this->encryptingKeyUrls;
+    }
+
+    public function setEncryptingKeyUrls(array $encryptingKeyUrls): self
+    {
+        Validator::value($encryptingKeyUrls)
+            ->unique()
+            ->validate();
+
+        $this->encryptingKeyUrls = $encryptingKeyUrls;
+        return $this;
+    }
+
+    public function getAcknowledgementUrls(): array
+    {
+        return $this->acknowledgementUrls;
+    }
+
+    public function setAcknowledgementUrls(array $acknowledgementUrls): self
+    {
+        Validator::value($acknowledgementUrls)
+            ->unique()
+            ->validate();
+
+        $this->acknowledgementUrls = $acknowledgementUrls;
+        return $this;
+    }
+
+    public function getPolicyUrls(): array
+    {
+        return $this->policyUrls;
+    }
+
+    public function setPolicyUrls(array $policyUrls): self
+    {
+        Validator::value($policyUrls)
+            ->unique()
+            ->validate();
+
+        $this->policyUrls = $policyUrls;
+        return $this;
+    }
+
+    public function getOpeningUrls(): array
+    {
+        return $this->openingUrls;
+    }
+
+    public function setOpeningUrls(array $openingUrls): self
+    {
+        Validator::value($openingUrls)
+            ->unique()
+            ->validate();
+
+        $this->openingUrls = $openingUrls;
+        return $this;
+    }
+
+    public function getPreferredLanguages(): array
+    {
+        return $this->preferredLanguages;
+    }
+
+    public function setPreferredLanguages(array $preferredLanguages): self
+    {
+        Validator::value($preferredLanguages)
+            ->unique()
+            ->validate();
+
+        $this->preferredLanguages = $preferredLanguages;
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): self
+    {
+        $this->clusterId = $clusterId;
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setExpiresTimestamp(Arr::get($data, 'expires_timestamp'))
+            ->setEmailContacts(Arr::get($data, 'email_contacts'))
+            ->setUrlContacts(Arr::get($data, 'url_contacts'))
+            ->setEncryptingKeyUrls(Arr::get($data, 'encrypting_key_urls'))
+            ->setAcknowledgementUrls(Arr::get($data, 'acknowledgement_urls'))
+            ->setPolicyUrls(Arr::get($data, 'policy_urls'))
+            ->setOpeningUrls(Arr::get($data, 'opening_urls'))
+            ->setPreferredLanguages(Arr::get($data, 'preferred_languages'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'expires_timestamp' => $this->getExpiresTimestamp(),
+            'email_contacts' => $this->getEmailContacts(),
+            'url_contacts' => $this->getUrlContacts(),
+            'encrypting_key_urls' => $this->getEncryptingKeyUrls(),
+            'acknowledgement_urls' => $this->getAcknowledgementUrls(),
+            'policy_urls' => $this->getPolicyUrls(),
+            'opening_urls' => $this->getOpeningUrls(),
+            'preferred_languages' => $this->getPreferredLanguages(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}


### PR DESCRIPTION
# Changes

### Added

- CertificateManagers: Add restore endpoint.
- Clusters: Add common properties endpoint.
- Clusters: Add create endpoint.
- Clusters: Add update endpoint.
- Clusters: Add destroy endpoint.
- Crons: Add `timeout_seconds`.
- Databases: Add update endpoint.
- HAProxy Listens: Add completely new endpoints.
- HAProxy Listens To Nodes: Add completely new endpoints.
- Nodes: Add create endpoint.
- Nodes: Add update endpoint.
- Nodes: Add destroy endpoint.
- Nodes: Add `maldet` node group.
- SecurityTxtPolicies: Add completely new endpoints.

### Changed

- Clusters: Change `customer_id` validation.
- Update to [API version 1.198.2](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.198.2-2023-09-20).

### Removed

- Clusters: Remove `name` fields.
- Nodes: Remove `hostname` field.
- Nodes: Remove `Main` node group.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
