### PR TITLE
Restore name field in cluster update endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.102.1]
+
+### Fixed
+
+- Clusters: Add `name` field back to the update endpoint.
+
 ## [1.102.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.102.0';
+    private const VERSION = '1.102.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -149,6 +149,7 @@ class Clusters extends Endpoint
     public function update(Cluster $cluster): Response
     {
         $this->validateRequired($cluster, 'update', [
+            'name',
             'groups',
             'unix_user_home_directory',
             'php_versions',
@@ -183,6 +184,7 @@ class Clusters extends Endpoint
             ->setUrl(sprintf('clusters/%d', $cluster->getId()))
             ->setBody(
                 $this->filterFields($cluster->toArray(), [
+                    'name',
                     'groups',
                     'unix_user_home_directory',
                     'php_versions',


### PR DESCRIPTION
# Changes

### Fixed

- Clusters: Add `name` field back to the update endpoint.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
