### PR TITLE
Add missing endpoints to cluster API entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.102.2]
+
+### Added
+
+- Add missing endpoints to cluster API entry point.
+
 ## [1.102.1]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.102.1';
+    private const VERSION = '1.102.2';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -21,6 +21,8 @@ use Cyberfusion\ClusterApi\Endpoints\DomainRouters;
 use Cyberfusion\ClusterApi\Endpoints\FirewallGroups;
 use Cyberfusion\ClusterApi\Endpoints\FpmPools;
 use Cyberfusion\ClusterApi\Endpoints\FtpUsers;
+use Cyberfusion\ClusterApi\Endpoints\HAProxyListens;
+use Cyberfusion\ClusterApi\Endpoints\HAProxyListensToNodes;
 use Cyberfusion\ClusterApi\Endpoints\Health;
 use Cyberfusion\ClusterApi\Endpoints\HtpasswdFiles;
 use Cyberfusion\ClusterApi\Endpoints\HtpasswdUsers;
@@ -34,6 +36,7 @@ use Cyberfusion\ClusterApi\Endpoints\Nodes;
 use Cyberfusion\ClusterApi\Endpoints\PassengerApps;
 use Cyberfusion\ClusterApi\Endpoints\RedisInstances;
 use Cyberfusion\ClusterApi\Endpoints\RootSshKeys;
+use Cyberfusion\ClusterApi\Endpoints\SecurityTxtPolicies;
 use Cyberfusion\ClusterApi\Endpoints\SshKeys;
 use Cyberfusion\ClusterApi\Endpoints\TaskCollections;
 use Cyberfusion\ClusterApi\Endpoints\Tombstones;
@@ -137,6 +140,16 @@ class ClusterApi
         return new FtpUsers($this->client);
     }
 
+    public function haProxyListens(): HAProxyListens
+    {
+        return new HAProxyListens($this->client);
+    }
+
+    public function haProxyListensToNodes(): HAProxyListensToNodes
+    {
+        return new HAProxyListensToNodes($this->client);
+    }
+
     public function health(): Health
     {
         return new Health($this->client);
@@ -200,6 +213,11 @@ class ClusterApi
     public function rootSshKeys(): RootSshKeys
     {
         return new RootSshKeys($this->client);
+    }
+
+    public function securityTxtPolicies(): SecurityTxtPolicies
+    {
+        return new SecurityTxtPolicies($this->client);
     }
 
     public function sshKeys(): SshKeys


### PR DESCRIPTION
# Changes

### Added

- Add missing endpoints to cluster API entry point.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
