### PR TITLE
Add hostname field back to the update endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.102.3]
+
+### Added
+
+- Node: Add `hostname` field back to the update endpoint.
+
 ## [1.102.2]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.102.2';
+    private const VERSION = '1.102.3';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/Nodes.php
+++ b/src/Endpoints/Nodes.php
@@ -109,6 +109,7 @@ class Nodes extends Endpoint
             'groups_properties',
             'cluster_id',
             'id',
+            'hostname',
         ]);
 
         $request = (new Request())
@@ -122,6 +123,7 @@ class Nodes extends Endpoint
                     'groups_properties',
                     'cluster_id',
                     'id',
+                    'hostname',
                 ])
             );
 

--- a/src/Models/Node.php
+++ b/src/Models/Node.php
@@ -130,7 +130,7 @@ class Node extends ClusterModel
         return $this->hostname;
     }
 
-    public function setHostname(?string $hostname): Node
+    public function setHostname(?string $hostname): self
     {
         $this->hostname = $hostname;
         return $this;

--- a/src/Models/Node.php
+++ b/src/Models/Node.php
@@ -16,6 +16,7 @@ class Node extends ClusterModel
     private ?int $clusterId = null;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
+    private ?string $hostname = null;
 
     public function getGroups(): ?array
     {
@@ -124,6 +125,17 @@ class Node extends ClusterModel
         return $this;
     }
 
+    public function getHostname(): ?string
+    {
+        return $this->hostname;
+    }
+
+    public function setHostname(?string $hostname): Node
+    {
+        $this->hostname = $hostname;
+        return $this;
+    }
+
     public function fromArray(array $data): self
     {
         return $this
@@ -134,7 +146,8 @@ class Node extends ClusterModel
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
-            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+            ->setUpdatedAt(Arr::get($data, 'updated_at'))
+            ->setHostname(Arr::get($data, 'hostname'));
     }
 
     public function toArray(): array
@@ -148,6 +161,7 @@ class Node extends ClusterModel
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),
             'updated_at' => $this->getUpdatedAt(),
+            'hostname' => $this->getHostname(),
         ];
     }
 }


### PR DESCRIPTION
# Changes

### Added

- Node: Add `hostname` field back to the update endpoint.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
