### PR TITLE
Add `cluster_id` when creating a public or private root ssh key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.102.4]
+
+### Fixed
+
+- RootSshKeys: Add `cluster_id` when creating a public or private ssh key.
+
 ## [1.102.3]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.102.3';
+    private const VERSION = '1.102.4';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/RootSshKeys.php
+++ b/src/Endpoints/RootSshKeys.php
@@ -67,6 +67,7 @@ class RootSshKeys extends Endpoint
         $this->validateRequired($rootSshKey, 'create', [
             'name',
             'public_key',
+            'cluster_id',
         ]);
 
         $request = (new Request())
@@ -76,6 +77,7 @@ class RootSshKeys extends Endpoint
                 $this->filterFields($rootSshKey->toArray(), [
                     'name',
                     'public_key',
+                    'cluster_id',
                 ])
             );
 
@@ -98,6 +100,7 @@ class RootSshKeys extends Endpoint
         $this->validateRequired($rootSshKey, 'create', [
             'name',
             'private_key',
+            'cluster_id',
         ]);
 
         $request = (new Request())
@@ -107,6 +110,7 @@ class RootSshKeys extends Endpoint
                 $this->filterFields($rootSshKey->toArray(), [
                     'name',
                     'private_key',
+                    'cluster_id',
                 ])
             );
 


### PR DESCRIPTION
# Changes

### Fixed

- RootSshKeys: Add `cluster_id` when creating a public or private ssh key.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
