### PR TITLE
Remove customer_id validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.102.5]
+
+### Fixed
+
+- Clusters: `customer_id` is no longer validated.
+
 ## [1.102.4]
 
 ### Fixed
 
-- RootSshKeys: Add `cluster_id` when creating a public or private ssh key.
+- RootSshKeys: Add `cluster_id` when creating a public or private SSH key.
 
 ## [1.102.3]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.198.2** version of the API.
+This client was built for and tested on the **1.199** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.102.4';
+    private const VERSION = '1.102.5';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -233,12 +233,6 @@ class Cluster extends ClusterModel
 
     public function setCustomerId(?int $customerId): self
     {
-        Validator::value($customerId)
-            ->nullable()
-            ->minAmount(0)
-            ->pattern('^[0-9]+$')
-            ->validate();
-
         $this->customerId = $customerId;
 
         return $this;


### PR DESCRIPTION
# Changes

Remove `customer_id` validation, as `customer_id` now an ID referring to an external model.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
