### PR TITLE
Version 1.103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.103]
+
+### Changed
+
+- CustomConfigSnippets: create endpoints have been split.
+
 ## [1.102.5]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.102.5';
+    private const VERSION = '1.103';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/CustomConfigSnippets.php
+++ b/src/Endpoints/CustomConfigSnippets.php
@@ -62,11 +62,12 @@ class CustomConfigSnippets extends Endpoint
     /**
      * @throws RequestException
      */
-    public function create(CustomConfigSnippet $customConfigSnippet): Response
+    public function createFromContents(CustomConfigSnippet $customConfigSnippet): Response
     {
         $this->validateRequired($customConfigSnippet, 'create', [
             'name',
             'server_software_name',
+            'contents',
             'cluster_id',
         ]);
 
@@ -74,13 +75,54 @@ class CustomConfigSnippets extends Endpoint
             ->setMethod(Request::METHOD_POST)
             ->setUrl('custom-config-snippets')
             ->setBody(
-                $this->filterFields($customConfigSnippet->toArray(), [
-                    'name',
-                    'server_software_name',
-                    'cluster_id',
-                    'contents',
-                    'template_name',
-                ])
+                array_merge(
+                    $this->filterFields($customConfigSnippet->toArray(), [
+                        'name',
+                        'server_software_name',
+                        'cluster_id',
+                        'contents',
+                    ]),
+                    ['template_name' => null]
+                )
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'customConfigSnippet' => (new CustomConfigSnippet())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function createFromTemplate(CustomConfigSnippet $customConfigSnippet): Response
+    {
+        $this->validateRequired($customConfigSnippet, 'create', [
+            'name',
+            'server_software_name',
+            'template_name',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('custom-config-snippets')
+            ->setBody(
+                array_merge(
+                    $this->filterFields($customConfigSnippet->toArray(), [
+                        'name',
+                        'server_software_name',
+                        'cluster_id',
+                        'template_name',
+                    ]),
+                    ['contents' => null]
+                )
             );
 
         $response = $this


### PR DESCRIPTION
# Changes

Create endpoints have been split.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
