### PR TITLE
Bugfix/security txt policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
-## [1.104]
+## [1.103.1]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.104]
+
+### Fixed
+
+- DomainRouters: add `security_txt_policy_id` to model and endpoint.
+
 ## [1.103]
 
 ### Changed

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.103';
+    private const VERSION = '1.104';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.104';
+    private const VERSION = '1.103.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/DomainRouters.php
+++ b/src/Endpoints/DomainRouters.php
@@ -66,6 +66,7 @@ class DomainRouters extends Endpoint
                     'force_ssl',
                     'id',
                     'cluster_id',
+                    'security_txt_policy_id',
                 ])
             );
 

--- a/src/Models/DomainRouter.php
+++ b/src/Models/DomainRouter.php
@@ -16,7 +16,7 @@ class DomainRouter extends ClusterModel
     private int $clusterId;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
-    private ?string $securityTxtPolicyId = null;
+    private ?int $securityTxtPolicyId = null;
 
     public function getDomain(): string
     {
@@ -138,12 +138,12 @@ class DomainRouter extends ClusterModel
         return $this;
     }
 
-    public function getSecurityTxtPolicyId(): ?string
+    public function getSecurityTxtPolicyId(): ?int
     {
         return $this->securityTxtPolicyId;
     }
 
-    public function setSecurityTxtPolicyId(?string $securityTxtPolicyId): self
+    public function setSecurityTxtPolicyId(?int $securityTxtPolicyId): self
     {
         $this->securityTxtPolicyId = $securityTxtPolicyId;
 

--- a/src/Models/DomainRouter.php
+++ b/src/Models/DomainRouter.php
@@ -16,6 +16,7 @@ class DomainRouter extends ClusterModel
     private int $clusterId;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
+    private ?string $securityTxtPolicyId = null;
 
     public function getDomain(): string
     {
@@ -137,6 +138,18 @@ class DomainRouter extends ClusterModel
         return $this;
     }
 
+    public function getSecurityTxtPolicyId(): ?string
+    {
+        return $this->securityTxtPolicyId;
+    }
+
+    public function setSecurityTxtPolicyId(?string $securityTxtPolicyId): self
+    {
+        $this->securityTxtPolicyId = $securityTxtPolicyId;
+
+        return $this;
+    }
+
     public function fromArray(array $data): self
     {
         return $this
@@ -147,6 +160,7 @@ class DomainRouter extends ClusterModel
             ->setNodeId(Arr::get($data, 'node_id'))
             ->setCertificateId(Arr::get($data, 'certificate_id'))
             ->setId(Arr::get($data, 'id'))
+            ->setSecurityTxtPolicyId(Arr::get($data, 'security_txt_policy_id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
             ->setUpdatedAt(Arr::get($data, 'updated_at'));
@@ -162,6 +176,7 @@ class DomainRouter extends ClusterModel
             'node_id' => $this->getNodeId(),
             'certificate_id' => $this->getCertificateId(),
             'id' => $this->getId(),
+            'security_txt_policy_id' => $this->getSecurityTxtPolicyId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),
             'updated_at' => $this->getUpdatedAt(),


### PR DESCRIPTION
# Changes

Add missing 'security_txt_policy_id' for the DomainRouter model and endpoint


# Checks

- [X] The version constant is updated in `Client.php`
- [X] The changelog is updated (when applicable)
