### PR TITLE
Fix custom config snippet create + update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.103.4]
+
+## Fixed
+
+- CustomConfigSnippets: create and update.
+
 ## [1.103.3]
 
 ## Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.103.3';
+    private const VERSION = '1.103.4';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/CustomConfigSnippets.php
+++ b/src/Endpoints/CustomConfigSnippets.php
@@ -75,15 +75,13 @@ class CustomConfigSnippets extends Endpoint
             ->setMethod(Request::METHOD_POST)
             ->setUrl('custom-config-snippets')
             ->setBody(
-                array_merge(
-                    $this->filterFields($customConfigSnippet->toArray(), [
-                        'name',
-                        'server_software_name',
-                        'cluster_id',
-                        'contents',
-                    ]),
-                    ['template_name' => null]
-                )
+                $this->filterFields($customConfigSnippet->toArray(), [
+                    'name',
+                    'server_software_name',
+                    'cluster_id',
+                    'contents',
+                    'is_default',
+                ])
             );
 
         $response = $this
@@ -114,15 +112,13 @@ class CustomConfigSnippets extends Endpoint
             ->setMethod(Request::METHOD_POST)
             ->setUrl('custom-config-snippets')
             ->setBody(
-                array_merge(
-                    $this->filterFields($customConfigSnippet->toArray(), [
-                        'name',
-                        'server_software_name',
-                        'cluster_id',
-                        'template_name',
-                    ]),
-                    ['contents' => null]
-                )
+                $this->filterFields($customConfigSnippet->toArray(), [
+                    'name',
+                    'server_software_name',
+                    'cluster_id',
+                    'template_name',
+                    'is_default',
+                ])
             );
 
         $response = $this
@@ -148,6 +144,8 @@ class CustomConfigSnippets extends Endpoint
             'cluster_id',
             'id',
             'contents',
+            'template_name',
+            'is_default',
         ]);
 
         $request = (new Request())
@@ -160,6 +158,8 @@ class CustomConfigSnippets extends Endpoint
                     'cluster_id',
                     'id',
                     'contents',
+                    'template_name',
+                    'is_default',
                 ])
             );
 


### PR DESCRIPTION
# Changes

Fix custom config snippet create + update.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
