### PR TITLE
Fix creating Redis instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.103.8]
+
+### Fixed
+
+- Redis Instances: create.
+
 ## [1.103.7]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.103.7';
+    private const VERSION = '1.103.8';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/RedisInstances.php
+++ b/src/Endpoints/RedisInstances.php
@@ -67,7 +67,6 @@ class RedisInstances extends Endpoint
         $this->validateRequired($redisInstance, 'create', [
             'name',
             'password',
-            'primary_node_id',
             'cluster_id',
         ]);
 
@@ -81,7 +80,6 @@ class RedisInstances extends Endpoint
                     'memory_limit',
                     'eviction_policy',
                     'max_databases',
-                    'primary_node_id',
                     'cluster_id',
                 ])
             );
@@ -108,7 +106,6 @@ class RedisInstances extends Endpoint
         $this->validateRequired($redisInstance, 'update', [
             'name',
             'password',
-            'primary_node_id',
             'cluster_id',
             'id',
             'port',
@@ -124,7 +121,6 @@ class RedisInstances extends Endpoint
                     'max_databases',
                     'memory_limit',
                     'eviction_policy',
-                    'primary_node_id',
                     'cluster_id',
                     'id',
                     'port',

--- a/src/Models/RedisInstance.php
+++ b/src/Models/RedisInstance.php
@@ -14,7 +14,6 @@ class RedisInstance extends ClusterModel
     private ?int $port = null;
     private int $memoryLimit = 100;
     private string $evictionPolicy;
-    private int $primaryNodeId;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -107,18 +106,6 @@ class RedisInstance extends ClusterModel
         return $this;
     }
 
-    public function getPrimaryNodeId(): int
-    {
-        return $this->primaryNodeId;
-    }
-
-    public function setPrimaryNodeId(int $primaryNodeId): self
-    {
-        $this->primaryNodeId = $primaryNodeId;
-
-        return $this;
-    }
-
     public function getId(): ?int
     {
         return $this->id;
@@ -176,7 +163,6 @@ class RedisInstance extends ClusterModel
             ->setPort(Arr::get($data, 'port'))
             ->setMemoryLimit(Arr::get($data, 'memory_limit'))
             ->setEvictionPolicy(Arr::get($data, 'eviction_policy'))
-            ->setPrimaryNodeId(Arr::get($data, 'primary_node_id'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -192,7 +178,6 @@ class RedisInstance extends ClusterModel
             'port' => $this->getPort(),
             'memory_limit' => $this->getMemoryLimit(),
             'eviction_policy' => $this->getEvictionPolicy(),
-            'primary_node_id' => $this->getPrimaryNodeId(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),


### PR DESCRIPTION
# Changes

Fix creating Redis instances by removing `primary_node_id` (removed from API).

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
