### PR TITLE
Fix typo in required 'unix_users_home_directory'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.103.9]
+
+### Fixed
+
+- Clusters: create and update, due to typo in required 'unix_users_home_directory'.
+
 ## [1.103.8]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.103.8';
+    private const VERSION = '1.103.9';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -70,7 +70,7 @@ class Clusters extends Endpoint
     {
         $this->validateRequired($cluster, 'create', [
             'groups',
-            'unix_user_home_directory',
+            'unix_users_home_directory',
             'php_versions',
             'mariadb_version',
             'nodejs_version',
@@ -103,7 +103,7 @@ class Clusters extends Endpoint
             ->setBody(
                 $this->filterFields($cluster->toArray(), [
                     'groups',
-                    'unix_user_home_directory',
+                    'unix_users_home_directory',
                     'php_versions',
                     'mariadb_version',
                     'nodejs_version',
@@ -151,7 +151,7 @@ class Clusters extends Endpoint
         $this->validateRequired($cluster, 'update', [
             'name',
             'groups',
-            'unix_user_home_directory',
+            'unix_users_home_directory',
             'php_versions',
             'mariadb_version',
             'nodejs_version',
@@ -186,7 +186,7 @@ class Clusters extends Endpoint
                 $this->filterFields($cluster->toArray(), [
                     'name',
                     'groups',
-                    'unix_user_home_directory',
+                    'unix_users_home_directory',
                     'php_versions',
                     'mariadb_version',
                     'nodejs_version',


### PR DESCRIPTION
# Changes

Fix typo in required 'unix_users_home_directory'.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
