### PR TITLE
Fix issue with retrieving the unix user usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.104.1]
+
+### Fixed
+
+- UnixUser: the validation of the files when retrieving the usages was incorrect.
+
 ## [1.104]
 
 Update to Cluster API version 1.208.

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.104';
+    private const VERSION = '1.104.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Models/UnixUserUsage.php
+++ b/src/Models/UnixUserUsage.php
@@ -3,7 +3,6 @@
 namespace Cyberfusion\ClusterApi\Models;
 
 use Cyberfusion\ClusterApi\Support\Arr;
-use Cyberfusion\ClusterApi\Support\Validator;
 
 class UnixUserUsage extends ClusterModel
 {
@@ -43,12 +42,6 @@ class UnixUserUsage extends ClusterModel
 
     public function setFiles(?array $files): self
     {
-        Validator::value($files)
-            ->nullable()
-            ->each()
-            ->path()
-            ->validate();
-
         $this->files = $files;
 
         return $this;


### PR DESCRIPTION
# Changes

### Fixed

- UnixUser: the validation of the files when retrieving the usages was incorrect.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
