### PR TITLE
Fix object_id type of task collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.104.2]
+
+### Fixed
+
+- TaskCollection: use int|null as proper type for the object ID instead of string.
+
 ## [1.104.1]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.104.1';
+    private const VERSION = '1.104.2';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Models/TaskCollection.php
+++ b/src/Models/TaskCollection.php
@@ -11,7 +11,7 @@ class TaskCollection extends ClusterModel
     private string $uuid;
     private string $description;
     private string $collectionType;
-    private ?string $objectId = null;
+    private ?int $objectId = null;
     private string $objectModelName;
     private ?int $id = null;
     private ?int $clusterId = null;
@@ -63,12 +63,12 @@ class TaskCollection extends ClusterModel
         return $this;
     }
 
-    public function getObjectId(): ?string
+    public function getObjectId(): ?int
     {
         return $this->objectId;
     }
 
-    public function setObjectId(?string $objectId): self
+    public function setObjectId(?int $objectId): self
     {
         $this->objectId = $objectId;
 


### PR DESCRIPTION
# Changes

### Fixed

- TaskCollection: use int|null as proper type for the object ID instead of string.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
