### PR TITLE
Update to Cluster API version 1.214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.105.0]
+
+### Added
+
+- Add `ipAddresses` endpoint for customers.
+- Add `ipAddresses` endpoint for clusters.
+- Add `automatic_upgrades_enabled` property to the Cluster model.
+- Add `retry` endpoint for task collections.
+- Add option to list filter to include soft deleted items (currently only used for CertificateManagers).
+
+### Changed
+
+- Update to [API version 1.214.0](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.214-2023-11-29).
+
 ## [1.104.2]
 
 ### Fixed
@@ -20,7 +34,9 @@ for detailed information.
 
 ## [1.104]
 
-Update to Cluster API version 1.208.
+### Changed
+
+- Update to Cluster API version 1.208.
 
 ## [1.103.9]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.208** version of the API.
+This client was built for and tested on the **1.214** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.104.2';
+    private const VERSION = '1.105.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -14,6 +14,7 @@ use Cyberfusion\ClusterApi\Endpoints\Clusters;
 use Cyberfusion\ClusterApi\Endpoints\Cmses;
 use Cyberfusion\ClusterApi\Endpoints\Crons;
 use Cyberfusion\ClusterApi\Endpoints\CustomConfigSnippets;
+use Cyberfusion\ClusterApi\Endpoints\Customers;
 use Cyberfusion\ClusterApi\Endpoints\Databases;
 use Cyberfusion\ClusterApi\Endpoints\DatabaseUserGrants;
 use Cyberfusion\ClusterApi\Endpoints\DatabaseUsers;
@@ -98,6 +99,11 @@ class ClusterApi
     public function crons(): Crons
     {
         return new Crons($this->client);
+    }
+
+    public function customers(): Customers
+    {
+        return new Customers($this->client);
     }
 
     public function customConfigSnippets(): CustomConfigSnippets

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -6,6 +6,7 @@ use Cyberfusion\ClusterApi\Enums\TimeUnit;
 use Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Cyberfusion\ClusterApi\Models\Cluster;
 use Cyberfusion\ClusterApi\Models\ClusterCommonProperties;
+use Cyberfusion\ClusterApi\Models\HostIpAddress;
 use Cyberfusion\ClusterApi\Models\UnixUsersHomeDirectoryUsage;
 use Cyberfusion\ClusterApi\Request;
 use Cyberfusion\ClusterApi\Response;
@@ -352,6 +353,29 @@ class Clusters extends Endpoint
 
         return $response->setData([
             'commonProperties' => (new ClusterCommonProperties())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function ipAddresses(int $clusterId): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('clusters/%d/ip-addresses', $clusterId));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $ipAddresses = [];
+        foreach ($response->getData() as $name => $data) {
+            $ipAddresses[$name] = (new HostIpAddress())->fromArray($data);
+        }
+
+        return $response->setData([
+            'ipAddresses' => $ipAddresses,
         ]);
     }
 }

--- a/src/Endpoints/Customers.php
+++ b/src/Endpoints/Customers.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Endpoints;
+
+use Cyberfusion\ClusterApi\Models\HostIpAddress;
+use Cyberfusion\ClusterApi\Request;
+use Cyberfusion\ClusterApi\Response;
+
+class Customers extends Endpoint
+{
+    public function ipAddresses(int $customerId): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('customers/%d/ip-addresses', $customerId));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $ipAddresses = [];
+        foreach ($response->getData() as $name => $data) {
+            $ipAddresses[$name] = (new HostIpAddress())->fromArray($data);
+        }
+
+        return $response->setData([
+            'ipAddresses' => $ipAddresses,
+        ]);
+    }
+}

--- a/src/Endpoints/TaskCollections.php
+++ b/src/Endpoints/TaskCollections.php
@@ -3,9 +3,11 @@
 namespace Cyberfusion\ClusterApi\Endpoints;
 
 use Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Cyberfusion\ClusterApi\Models\TaskCollection;
 use Cyberfusion\ClusterApi\Models\TaskResult;
 use Cyberfusion\ClusterApi\Request;
 use Cyberfusion\ClusterApi\Response;
+use Cyberfusion\ClusterApi\Support\Str;
 
 class TaskCollections extends Endpoint
 {
@@ -30,6 +32,32 @@ class TaskCollections extends Endpoint
                 fn (array $data) => (new TaskResult())->fromArray($data),
                 $response->getData()
             ),
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function retry(string $uuid, ?string $callbackUrl = null): Response
+    {
+        $url = Str::optionalQueryParameters(
+            sprintf('task-collections/%s/retry', $uuid),
+            ['callback_url' => $callbackUrl]
+        );
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl($url);
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'taskCollection' => (new TaskCollection())->fromArray($response->getData()),
         ]);
     }
 }

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -42,6 +42,7 @@ class Cluster extends ClusterModel
     private ?bool $syncToolkitEnabled = null;
     private ?bool $automaticBorgRepositoriesPruneEnabled = null;
     private ?bool $phpSessionSpreadEnabled = null;
+    private ?bool $automaticUpgradesEnabled = null;
     private string $description;
     private ?int $id = null;
     private ?string $createdAt = null;
@@ -501,6 +502,18 @@ class Cluster extends ClusterModel
         return $this;
     }
 
+    public function getAutomaticUpgradesEnabled(): ?bool
+    {
+        return $this->automaticUpgradesEnabled;
+    }
+
+    public function setAutomaticUpgradesEnabled(?bool $automaticUpgradesEnabled): self
+    {
+        $this->automaticUpgradesEnabled = $automaticUpgradesEnabled;
+
+        return $this;
+    }
+
     public function getDescription(): string
     {
         return $this->description;
@@ -584,6 +597,7 @@ class Cluster extends ClusterModel
             ->setSyncToolkitEnabled(Arr::get($data, 'sync_toolkit_enabled'))
             ->setAutomaticBorgRepositoriesPruneEnabled(Arr::get($data, 'automatic_borg_repositories_prune_enabled'))
             ->setPhpSessionSpreadEnabled(Arr::get($data, 'php_sessions_spread_enabled'))
+            ->setAutomaticUpgradesEnabled(Arr::get($data, 'automatic_upgrades_enabled'))
             ->setDescription(Arr::get($data, 'description'))
             ->setId(Arr::get($data, 'id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -629,6 +643,7 @@ class Cluster extends ClusterModel
             'meilisearch_master_key' => $this->getMeilisearchMasterKey(),
             'meilisearch_environment' => $this->getMeilisearchEnvironment(),
             'meilisearch_backup_interval' => $this->getMeilisearchBackupInterval(),
+            'automatic_upgrades_enabled' => $this->getAutomaticUpgradesEnabled(),
             'id' => $this->getId(),
             'created_at' => $this->getCreatedAt(),
             'updated_at' => $this->getUpdatedAt(),

--- a/src/Models/HostIpAddress.php
+++ b/src/Models/HostIpAddress.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+class HostIpAddress extends ClusterModel
+{
+    private string $name;
+    /**
+     * @var array<IpAddress>
+     */
+    private array $ipAddress = [];
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getIpAddress(): array
+    {
+        return $this->ipAddress;
+    }
+
+    public function setIpAddress(array $ipAddress = []): self
+    {
+        $this->ipAddress = $ipAddress;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setName(array_key_first($data))
+            ->setIpAddress(
+                array_map(
+                    fn (array $ipAddress) => (new IpAddress())->fromArray($ipAddress),
+                    $data[$this->getName()]
+                )
+            );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            $this->getName() => array_map(
+                fn (IpAddress $ipAddress) => $ipAddress->toArray(),
+                $this->getIpAddress()
+            )
+        ];
+    }
+}

--- a/src/Models/IpAddress.php
+++ b/src/Models/IpAddress.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use Cyberfusion\ClusterApi\Support\Arr;
+use Cyberfusion\ClusterApi\Support\Validator;
+
+class IpAddress extends ClusterModel
+{
+    private string $ipAddress;
+    private ?string $dnsName = null;
+
+    public function getIpAddress(): string
+    {
+        return $this->ipAddress;
+    }
+
+    public function setIpAddress(string $ipAddress): self
+    {
+        Validator::value($ipAddress)
+            ->ip()
+            ->validate();
+
+        $this->ipAddress = $ipAddress;
+
+        return $this;
+    }
+
+    public function getDnsName(): ?string
+    {
+        return $this->dnsName;
+    }
+
+    public function setDnsName(?string $dnsName): self
+    {
+        $this->dnsName = $dnsName;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setIpAddress(Arr::get($data, 'ip_address'))
+            ->setDnsName(Arr::get($data, 'dns_name'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'ip_address' => $this->getIpAddress(),
+            'dns_name' => $this->getDnsName()
+        ];
+    }
+}

--- a/src/Support/ListFilter.php
+++ b/src/Support/ListFilter.php
@@ -26,6 +26,7 @@ class ListFilter implements Filter
     private array $filter = [];
     /** @var array<SortEntry> */
     private array $sort = [];
+    private bool $includeSoftDeleted = false;
 
     /**
      * @param Model|class-string $model
@@ -202,6 +203,18 @@ class ListFilter implements Filter
         return $this;
     }
 
+    public function includeSoftDeleted(): bool
+    {
+        return $this->includeSoftDeleted;
+    }
+
+    public function setIncludeSoftDeleted(bool $includeSoftDeleted = false): self
+    {
+        $this->includeSoftDeleted = $includeSoftDeleted;
+
+        return $this;
+    }
+
     public function toQuery(): string
     {
         $builder = (new Builder())
@@ -212,6 +225,9 @@ class ListFilter implements Filter
         }
         foreach ($this->sort as $entry) {
             $builder->add('sort', $entry->toString());
+        }
+        if ($this->includeSoftDeleted) {
+            $builder->add('include_soft_deleted', 'true');
         }
         return $builder->build();
     }


### PR DESCRIPTION
# Changes

### Added

- Add `ipAddresses` endpoint for customers.
- Add `ipAddresses` endpoint for clusters.
- Add `automatic_upgrades_enabled` property to the Cluster model.
- Add `retry` endpoint for task collections.
- Add option to list filter to include soft deleted items (currently only used for CertificateManagers).

### Changed

- Update to [API version 1.214.0](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.214-2023-11-29).

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
