### PR TITLE
Add nullable() to validators where missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+# [1.108.1]
+
+### Fixed
+
+* In clusters, add `nullable()` to validators where missing.
+
 # [1.108.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.108.0';
+    private const VERSION = '1.108.1';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -218,6 +218,7 @@ class Cluster extends ClusterModel
             ->minLength(40)
             ->maxLength(40)
             ->pattern('^[a-zA-Z0-9]+$')
+            ->nullable()
             ->validate();
 
         $this->newRelicApmLicenseKey = $newRelicApmLicenseKey;
@@ -236,6 +237,7 @@ class Cluster extends ClusterModel
             ->minLength(24)
             ->maxLength(255)
             ->pattern('^[ -~]+$')
+            ->nullable()
             ->validate();
 
         $this->newRelicMariadbPassword = $newRelicMariadbPassword;
@@ -254,6 +256,7 @@ class Cluster extends ClusterModel
             ->minLength(40)
             ->maxLength(40)
             ->pattern('^[a-zA-Z0-9]+$')
+            ->nullable()
             ->validate();
 
         $this->newRelicInfrastructureLicenseKey = $newRelicInfrastructureLicenseKey;
@@ -272,6 +275,7 @@ class Cluster extends ClusterModel
             ->minLength(16)
             ->maxLength(24)
             ->pattern('^[a-zA-Z0-9]+$')
+            ->nullable()
             ->validate();
 
         $this->meilisearchMasterKey = $meilisearchMasterKey;


### PR DESCRIPTION
# Changes

See title.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
