### PR TITLE
Add nullable() to meilisearchEnvironment validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+# [1.108.2]
+
+### Fixed
+
+* In clusters, add `nullable()` to `meilisearchEnvironment` validator. This one was missed in 1.108.1.
+
 # [1.108.1]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.108.1';
+    private const VERSION = '1.108.2';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -292,6 +292,7 @@ class Cluster extends ClusterModel
     {
         Validator::value($meilisearchEnvironment)
             ->valueIn(MeilisearchEnvironment::AVAILABLE)
+            ->nullable()
             ->validate();
 
         $this->meilisearchEnvironment = $meilisearchEnvironment;


### PR DESCRIPTION
# Changes

In clusters, add `nullable()` to `meilisearchEnvironment` validator. This one was missed in 1.108.1.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
