### PR TITLE
Add Laravel 11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.0', '8.1', '8.2' ]
+        php-versions: [ '8.0', '8.1', '8.2', '8.3' ]
 
     name: PHP ${{ matrix.php-versions }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Cluster API
 
-on: [ push, pull_request ]
+on: [ push ]
 
 jobs:
   cluster-api-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+# [1.110.0]
+
+### Added
+
+- Add support for Laravel 11.
+
 # [1.109.0]
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
-        "illuminate/support": "^8.22 || ^9.0 || ^10.0",
+        "illuminate/support": "^8.22 || ^9.0 || ^10.0 || ^11.0",
         "nesbot/carbon": "^2.43",
         "ramsey/uuid": "^3.9 || ^4.0",
         "vdhicts/http-query-builder": "^1.0"

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.109.0';
+    private const VERSION = '1.110.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 


### PR DESCRIPTION
# Changes

### Added

- Add support for Laravel 11.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
