### PR TITLE
Improve validation and make field nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
-# [1.110.0]
+## [1.111.0]
+
+### Changed
+
+- Updated the minimum password length validation for the `HtpasswdUser` model.
+
+### Fixed
+
+- Change the `directory_path` to be nullable for the `BasicAuthenticationRealm` model.
+
+## [1.110.0]
 
 ### Added
 
 - Add support for Laravel 11.
 
-# [1.109.0]
+## [1.109.0]
 
 ### Changed
 
@@ -23,19 +33,19 @@ for detailed information.
 * Cluster malware toolkit attributes.
 * Firewall rules update endpoint.
 
-# [1.108.2]
+## [1.108.2]
 
 ### Fixed
 
 * In clusters, add `nullable()` to `meilisearchEnvironment` validator. This one was missed in 1.108.1.
 
-# [1.108.1]
+## [1.108.1]
 
 ### Fixed
 
 * In clusters, add `nullable()` to validators where missing.
 
-# [1.108.0]
+## [1.108.0]
 
 ### Added
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.110.0';
+    private const VERSION = '1.111.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Models/BasicAuthenticationRealm.php
+++ b/src/Models/BasicAuthenticationRealm.php
@@ -8,7 +8,7 @@ use Cyberfusion\ClusterApi\Support\Validator;
 class BasicAuthenticationRealm extends ClusterModel
 {
     private string $name;
-    private string $directoryPath;
+    private ?string $directoryPath;
     private int $virtualHostId;
     private int $htpasswdFileId;
     private ?int $id = null;
@@ -24,6 +24,7 @@ class BasicAuthenticationRealm extends ClusterModel
     public function setName(string $name): self
     {
         Validator::value($name)
+            ->minLength(1)
             ->maxLength(64)
             ->pattern('^[a-zA-Z0-9-_ ]+$')
             ->validate();
@@ -33,15 +34,16 @@ class BasicAuthenticationRealm extends ClusterModel
         return $this;
     }
 
-    public function getDirectoryPath(): string
+    public function getDirectoryPath(): ?string
     {
         return $this->directoryPath;
     }
 
-    public function setDirectoryPath(string $directoryPath): self
+    public function setDirectoryPath(?string $directoryPath): self
     {
         Validator::value($directoryPath)
             ->path()
+            ->nullable()
             ->validate();
 
         $this->directoryPath = $directoryPath;

--- a/src/Models/HtpasswdUser.php
+++ b/src/Models/HtpasswdUser.php
@@ -23,6 +23,7 @@ class HtpasswdUser extends ClusterModel
     public function setUsername(string $username): self
     {
         Validator::value($username)
+            ->minLength(1)
             ->maxLength(255)
             ->pattern('^[a-z0-9-_]+$')
             ->validate();
@@ -40,6 +41,7 @@ class HtpasswdUser extends ClusterModel
     public function setPassword(string $password): self
     {
         Validator::value($password)
+            ->minLength(24)
             ->maxLength(255)
             ->pattern('^[ -~]+$')
             ->validate();


### PR DESCRIPTION
# Changes

### Changed

- Updated the minimum password length validation for the `HtpasswdUser` model.

### Fixed

- Change the `directory_path` to be nullable for the `BasicAuthenticationRealm` model.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
