### PR TITLE
Revert "Let checks run on push"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Cluster API
 
-on: [ push ]
+on: [ push, pull_request ]
 
 jobs:
   cluster-api-tests:


### PR DESCRIPTION
This reverts commit 04b11aff9b3abf855b43cb9c0d9258da498af9db.

# Changes

Otherwise, PRs made from forks don't have a workflow to run.

# Checks

- [ ] The version constant is updated in `Client.php`
- [ ] The changelog is updated (when applicable)
- [ ] The supported Cluster API version is updated in the README (when applicable)
