### PR TITLE
✨ Update to API version 1.230.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.113.0]
+
+### Added
+
+- Add `gmp`, `vips`, `excimer`, `mailparse`, `uv` and `tideways` to `CustomPhpModuleName` enum.
+- Add Nextcloud CMS installation endpoint.
+
+### Changed
+
+- Updated WordPress CMS installation endpoint.
+
 ## [1.112.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.228** version of the API.
+This client was built for and tested on the **1.230.1** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.112.0';
+    private const VERSION = '1.113.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Endpoints/Cmses.php
+++ b/src/Endpoints/Cmses.php
@@ -114,10 +114,54 @@ class Cmses extends Endpoint
             ->request($request);
     }
 
+    public function installNextcloud(int $id, CmsInstallation $cmsInstallation, ?string $callbackUrl = null): Response
+    {
+        $this->validateRequired($cmsInstallation, 'create', [
+            'database_name',
+            'database_user_name',
+            'database_user_password',
+            'database_host',
+            'admin_username',
+            'admin_password',
+        ]);
+
+        $url = Str::optionalQueryParameters(
+            sprintf('cmses/%d/install/nextcloud', $id),
+            ['callback_url' => $callbackUrl]
+        );
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl($url)
+            ->setBody(
+                $this->filterFields($cmsInstallation->toArray(), [
+                    'database_name',
+                    'database_user_name',
+                    'database_user_password',
+                    'database_host',
+                    'admin_username',
+                    'admin_password',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $taskCollection = (new TaskCollection())->fromArray($response->getData());
+
+        return $response->setData([
+            'taskCollection' => $taskCollection,
+        ]);
+    }
+
     /**
      * @throws RequestException
      */
-    public function install(int $id, CmsInstallation $cmsInstallation, ?string $callbackUrl = null): Response
+    public function installWordpress(int $id, CmsInstallation $cmsInstallation, ?string $callbackUrl = null): Response
     {
         $this->validateRequired($cmsInstallation, 'create', [
             'database_name',
@@ -134,7 +178,7 @@ class Cmses extends Endpoint
         ]);
 
         $url = Str::optionalQueryParameters(
-            sprintf('cmses/%d/install', $id),
+            sprintf('cmses/%d/install/wordpress', $id),
             ['callback_url' => $callbackUrl]
         );
 

--- a/src/Enums/CustomPhpModuleName.php
+++ b/src/Enums/CustomPhpModuleName.php
@@ -17,4 +17,10 @@ class CustomPhpModuleName
     public const SQLSRV = 'sqlsrv';
     public const XDEBUG = 'xdebug';
     public const XMLRPC = 'xmlrpc';
+    public const GMP = 'gmp';
+    public const VIPS = 'vips';
+    public const EXCIMER = 'excimer';
+    public const MAILPARSE = 'mailparse';
+    public const UV = 'uv';
+    public const TIDEWAYS = 'tideways';
 }


### PR DESCRIPTION
# Changes

### Added

- Add `gmp`, `vips`, `excimer`, `mailparse`, `uv` and `tideways` to `CustomPhpModuleName` enum.
- Add Nextcloud CMS installation endpoint.

### Changed

- Updated WordPress CMS installation endpoint.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
