### PR TITLE
Fix DatabaseUser::$phpmyadminFirewallGroupsIds must not be accessed before initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.113.1]
+
+### Fixed
+
+- Fix DatabaseUser::$phpmyadminFirewallGroupsIds must not be accessed before initialization
+
 ## [1.113.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.113.0';
+    private const VERSION = '1.113.1';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Models/DatabaseUser.php
+++ b/src/Models/DatabaseUser.php
@@ -13,7 +13,7 @@ class DatabaseUser extends ClusterModel
 
     private string $name;
     private ?string $password;
-    private ?array $phpmyadminFirewallGroupsIds;
+    private ?array $phpmyadminFirewallGroupsIds = null;
     private string $host = self::DEFAULT_HOST;
     private string $serverSoftwareName = DatabaseEngine::SERVER_SOFTWARE_MARIADB;
     private ?int $id = null;


### PR DESCRIPTION
Closes https://github.com/CyberfusionIO/cyberfusion-cluster-api-client/issues/112

# Changes

### Fixed

- Fix DatabaseUser::$phpmyadminFirewallGroupsIds must not be accessed before initialization

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
