### PR TITLE
Require PHP 8.1 or newer. 8.0 is EOL.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.0', '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.1', '8.2', '8.3' ]
 
     name: PHP ${{ matrix.php-versions }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.114.1]
+
+### Changed
+
+- Bump minimum PHP version to 8.1.
+
 ## [1.114]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The client was created by @dvdheiden.
 
 ## Requirements
 
-This client requires PHP 8.0 or higher and uses Guzzle.
+This client requires PHP 8.1 or higher and uses Guzzle.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "https://github.com/CyberfusionIO/cyberfusion-cluster-api-client",
     "license": "MIT",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
         "illuminate/support": "^8.22 || ^9.0 || ^10.0 || ^11.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.114';
+    private const VERSION = '1.114.1';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 


### PR DESCRIPTION
# Changes

Require PHP 8.1 or newer.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
