### PR TITLE
Add missing ID to custom config update payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.114.2]
+
+### Fixed
+
+- Custom config update.
+
 ## [1.114.1]
 
 ### Changed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.114.1';
+    private const VERSION = '1.114.2';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Endpoints/CustomConfigs.php
+++ b/src/Endpoints/CustomConfigs.php
@@ -116,6 +116,7 @@ class CustomConfigs extends Endpoint
                     'server_software_name',
                     'contents',
                     'cluster_id',
+                    'id',
                 ])
             );
 


### PR DESCRIPTION
# Changes

Add missing ID to custom config update payload.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Core API version is updated in the README (when applicable)
