### PR TITLE
Drop Carbon as separate dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.115.0]
+
+### Removed
+
+- Drop Carbon as dependency as it is already present in illuminate/support, and it prevents issues when your project already uses Carbon v3.
+
 ## [1.114.2]
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,12 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
         "illuminate/support": "^8.22 || ^9.0 || ^10.0 || ^11.0",
-        "nesbot/carbon": "^2.43",
         "ramsey/uuid": "^3.9 || ^4.0",
         "vdhicts/http-query-builder": "^1.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.2",
-        "phpunit/phpunit": "^9.6|^10.0",
+        "phpunit/phpunit": "^9.6 || 10.0",
         "rector/rector": "^1.0.0",
         "symplify/easy-coding-standard": "^12.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
     <include>
       <directory suffix=".php">src/</directory>

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.114.2';
+    private const VERSION = '1.115.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 


### PR DESCRIPTION
# Changes

### Removed

- Drop Carbon as dependency as it is already present in illuminate/support, and it prevents issues when your project already uses Carbon v3.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Core API version is updated in the README (when applicable)
