### PR TITLE
Add CPU limits and memory limits to daemons + memory limits to FPM pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.116.0]
+
+### Added
+
+- CPU limits and memory limits to daemons.
+- Memory limits to FPM pools.
+
+Note: new `updatePartial` methods were added to update these attributes, as they can only be updated using the new PATCH endpoints
+in the Core API (not the now deprecated PUT endpoints, which the existing `update` methods used).
+
 ## [1.115.0]
 
 ### Removed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.115.0';
+    private const VERSION = '1.116.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Endpoints/Daemons.php
+++ b/src/Endpoints/Daemons.php
@@ -69,6 +69,8 @@ class Daemons extends Endpoint
           'command',
           'nodes_ids',
           'unix_user_id',
+          'memory_limit',
+          'cpu_limit',
         ]);
 
         $request = (new Request())
@@ -80,6 +82,8 @@ class Daemons extends Endpoint
                 'command',
                 'unix_user_id',
                 'nodes_ids',
+                'memory_limit',
+                'cpu_limit',
               ])
           );
 
@@ -136,6 +140,40 @@ class Daemons extends Endpoint
 
         return $response->setData([
           'daemon' => $daemon,
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function updatePartial(Daemon $daemon): Response
+    {
+        $this->validateRequired($daemon, 'update', [
+            'memory_limit',
+            'cpu_limit',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PATCH)
+            ->setUrl(sprintf('fpm-pools/%d', $daemon->getId()))
+            ->setBody(
+                $this->filterFields($daemon->toArray(), [
+                    'memory_limit',
+                    'cpu_limit',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $daemon = (new Daemon())->fromArray($response->getData());
+
+        return $response->setData([
+            'daemon' => $daemon,
         ]);
     }
 

--- a/src/Endpoints/FpmPools.php
+++ b/src/Endpoints/FpmPools.php
@@ -85,6 +85,7 @@ class FpmPools extends Endpoint
                     'max_requests',
                     'process_idle_timeout',
                     'cpu_limit',
+                    'memory_limit',
                     'log_slow_requests_threshold',
                     'is_namespaced',
                 ])
@@ -134,6 +135,38 @@ class FpmPools extends Endpoint
                     'is_namespaced',
                     'id',
                     'cluster_id',
+                ])
+            );
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $fpmPool = (new FpmPool())->fromArray($response->getData());
+
+        return $response->setData([
+            'fpmPool' => $fpmPool,
+        ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function updatePartial(FpmPool $fpmPool): Response
+    {
+        $this->validateRequired($fpmPool, 'update', [
+            'memory_limit',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PATCH)
+            ->setUrl(sprintf('fpm-pools/%d', $fpmPool->getId()))
+            ->setBody(
+                $this->filterFields($fpmPool->toArray(), [
+                    'memory_limit',
                 ])
             );
 

--- a/src/Models/Daemon.php
+++ b/src/Models/Daemon.php
@@ -10,6 +10,8 @@ class Daemon extends ClusterModel
     private string $name;
     private string $command;
     private int $unixUserId;
+    private ?int $memoryLimit;
+    private ?int $cpuLimit;
     private array $nodesIds;
     private ?int $id;
     private int $clusterId;
@@ -58,6 +60,30 @@ class Daemon extends ClusterModel
     public function setUnixUserId(int $unixUserId): self
     {
         $this->unixUserId = $unixUserId;
+
+        return $this;
+    }
+
+    public function getCpuLimit(): ?int
+    {
+        return $this->cpuLimit;
+    }
+
+    public function setCpuLimit(?int $cpuLimit): self
+    {
+        $this->cpuLimit = $cpuLimit;
+
+        return $this;
+    }
+
+    public function getMemoryLimit(): ?int
+    {
+        return $this->memoryLimit;
+    }
+
+    public function setMemoryLimit(?int $memoryLimit): self
+    {
+        $this->memoryLimit = $memoryLimit;
 
         return $this;
     }
@@ -128,6 +154,8 @@ class Daemon extends ClusterModel
           ->setName(Arr::get($data, 'name'))
           ->setCommand(Arr::get($data, 'command'))
           ->setUnixUserId(Arr::get($data, 'unix_user_id'))
+          ->setMemoryLimit(Arr::get($data, 'memory_limit'))
+          ->setCpuLimit(Arr::get($data, 'cpu_limit'))
           ->setNodesIds(Arr::get($data, 'nodes_ids'))
           ->setId(Arr::get($data, 'id'))
           ->setClusterId(Arr::get($data, 'cluster_id'))
@@ -141,6 +169,8 @@ class Daemon extends ClusterModel
           'name' => $this->getName(),
           'command' => $this->getCommand(),
           'unix_user_id' => $this->getUnixUserId(),
+          'memory_limit' => $this->getMemoryLimit(),
+          'cpu_limit' => $this->getCpuLimit(),
           'nodes_ids' => $this->getNodesIds(),
           'id' => $this->getId(),
           'cluster_id' => $this->getClusterId(),

--- a/src/Models/FpmPool.php
+++ b/src/Models/FpmPool.php
@@ -14,6 +14,7 @@ class FpmPool extends ClusterModel
     private int $maxRequests = 1000;
     private int $processIdleTimeout = 10;
     private ?int $cpuLimit = null;
+    private ?int $memoryLimit = null;
     private ?int $logShowRequestsThreshold = null;
     private bool $isNamespaced = false;
     private ?int $id = null;
@@ -110,6 +111,18 @@ class FpmPool extends ClusterModel
         return $this;
     }
 
+    public function getMemoryLimit(): ?int
+    {
+        return $this->memoryLimit;
+    }
+
+    public function setMemoryLimit(?int $memoryLimit): self
+    {
+        $this->memoryLimit = $memoryLimit;
+
+        return $this;
+    }
+
     public function getLogShowRequestsThreshold(): ?int
     {
         return $this->logShowRequestsThreshold;
@@ -192,6 +205,7 @@ class FpmPool extends ClusterModel
             ->setMaxRequests(Arr::get($data, 'max_requests'))
             ->setProcessIdleTimeout(Arr::get($data, 'process_idle_timeout'))
             ->setCpuLimit(Arr::get($data, 'cpu_limit'))
+            ->setMemoryLimit(Arr::get($data, 'memory_limit'))
             ->setLogShowRequestsThreshold(Arr::get($data, 'log_slow_requests_threshold'))
             ->setIsNamespaced((bool)Arr::get($data, 'is_namespaced'))
             ->setId(Arr::get($data, 'id'))
@@ -210,6 +224,7 @@ class FpmPool extends ClusterModel
             'max_requests' => $this->getMaxRequests(),
             'process_idle_timeout' => $this->getProcessIdleTimeout(),
             'cpu_limit' => $this->getCpuLimit(),
+            'memory_limit' => $this->getMemoryLimit(),
             'log_slow_requests_threshold' => $this->getLogShowRequestsThreshold(),
             'is_namespaced' => $this->isNamespaced(),
             'id' => $this->getId(),


### PR DESCRIPTION
# Changes

Added:

- CPU limits and memory limits to daemons.
- Memory limits to FPM pools.

Note: new `updatePartial` methods were added to update these attributes, as they can only be updated using the new PATCH endpoints in the Core API (not the now deprecated PUT endpoints, which the existing `update` methods used).

The client will be fully updated soon (https://github.com/CyberfusionIO/cyberfusion-cluster-api-client/issues/117). 

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Core API version is updated in the README (when applicable)
