### PR TITLE
Add support for HAProxy Listens `nodes_ids`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.117.0]
+
+### Added
+
+- `nodes_ids` to HAProxy listens
+
 ## [1.116.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Core API](https://core-api.cyberfusion.io/).
 
-This client was built for and tested on the **1.230.1** version of the API.
+This client was built for and tested on the **1.238.0** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.116.1';
+    private const VERSION = '1.117.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Endpoints/HAProxyListens.php
+++ b/src/Endpoints/HAProxyListens.php
@@ -67,6 +67,7 @@ class HAProxyListens extends Endpoint
         $this->validateRequired($haProxyListen, 'create', [
             'name',
             'nodes_group',
+            'nodes_ids',
             'port',
             'socket_path',
             'destination_cluster_id',
@@ -80,6 +81,7 @@ class HAProxyListens extends Endpoint
                 $this->filterFields($haProxyListen->toArray(), [
                     'name',
                     'nodes_group',
+                    'nodes_ids',
                     'port',
                     'socket_path',
                     'destination_cluster_id',

--- a/src/Models/HAProxyListen.php
+++ b/src/Models/HAProxyListen.php
@@ -13,6 +13,8 @@ class HAProxyListen extends ClusterModel
 
     private string $nodesGroup;
 
+    private ?array $nodesIds = null;
+
     private ?int $port = null;
 
     private ?string $socketPath = null;
@@ -57,6 +59,18 @@ class HAProxyListen extends ClusterModel
             ->validate();
 
         $this->nodesGroup = $nodesGroup;
+
+        return $this;
+    }
+
+    public function getNodesIds(): ?array
+    {
+        return $this->nodesIds;
+    }
+
+    public function setNodesIds(?array $nodesIds): self
+    {
+        $this->nodesIds = $nodesIds;
 
         return $this;
     }
@@ -162,6 +176,7 @@ class HAProxyListen extends ClusterModel
         return $this
             ->setName(Arr::get($data, 'name'))
             ->setNodesGroup(Arr::get($data, 'nodes_group'))
+            ->setNodesIds(Arr::get($data, 'nodes_ids'))
             ->setPort(Arr::get($data, 'port'))
             ->setSocketPath(Arr::get($data, 'socket_path'))
             ->setDestinationClusterId(Arr::get($data, 'destination_cluster_id'))
@@ -176,6 +191,7 @@ class HAProxyListen extends ClusterModel
         return [
             'name' => $this->getName(),
             'nodes_group' => $this->getNodesGroup(),
+            'nodes_ids' => $this->getNodesIds(),
             'port' => $this->getPort(),
             'socket_path' => $this->getSocketPath(),
             'destination_cluster_id' => $this->getDestinationClusterId(),


### PR DESCRIPTION
# Changes

Added support for the `nodes_ids` parameter for "HAProxy Listens" added in Core API "1.238.0". Please sanity check my changes :)

Tests pass, but I have not manually tested the client. Also, I did not take into account any changes between the previous tested Core API version (1.230.1), and the current one.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Core API version is updated in the README (when applicable)