### PR TITLE
Update to API version 1.238.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
 
     name: PHP ${{ matrix.php-versions }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ composer.lock
 /.idea/
 /build/
 .phpunit.result.cache
+.phpunit.cache
 
 # macOS
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ for detailed information.
 - Add `name` property to the `BorgArchiveMetadata` model.
 - Add `load_balancing_method` property to the `Cluster` model.
 - Add `load_balancing_method` property to the `HAProxyListen` model.
+- Add compatiblity for this client for PHP 8.4.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ for detailed information.
 
 ### Changed
 
-- - Update to [API version 1.238.0](https://core-api.cyberfusion.io/redoc#section/Changelog/1.238.0-2024-12-27).
+- Update to [API version 1.238.0](https://core-api.cyberfusion.io/redoc#section/Changelog/1.238.0-2024-12-27).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ for detailed information.
 - Add `name` property to the `BorgArchiveMetadata` model.
 - Add `load_balancing_method` property to the `Cluster` model.
 - Add `load_balancing_method` property to the `HAProxyListen` model.
-- Add compatiblity for this client for PHP 8.4.
+- Add compatibility for this client for PHP 8.4.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.118.0]
+
+### Added
+
+- Add NextCloud endpoints.
+- Add `index` property to `CmsConfigurationContstant` and add it to the request body.
+- Add plugin methods to CMSes endpoint.
+- Add `reference` property to the `TaskCollection` model.
+- Add `deploymentResults` method to the `Cluster` endpoint.
+- Add `ClamAV` as node group.
+- Add `AWS` as option for the `external_provider_name` property of the `FirewallRule` model.
+- Add `name` property to the `BorgArchiveMetadata` model.
+- Add `load_balancing_method` property to the `Cluster` model.
+- Add `load_balancing_method` property to the `HAProxyListen` model.
+
+### Changed
+
+- - Update to [API version 1.238.0](https://core-api.cyberfusion.io/redoc#section/Changelog/1.238.0-2024-12-27).
+
+### Fixed
+
+- Fix task collection return when just the `task_collection_uuid` is returned.
+
+### Removed
+
+- Removed the `show_raw_message` parameter from the LogFilter as the raw message is now always returned.
+- Removed the `restore` method of the `CertificateManagers` endpoint as Certificate Manager are no longer soft-deleted.
+
 ## [1.117.1]
 
 ### Fixed

--- a/rector.php
+++ b/rector.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
-use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
-use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Rector\Set\ValueObject\SetList;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        SetList::PHP_80,
+        SetList::PHP_81,
         SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
     ]);
@@ -22,9 +20,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->skip([
-        AddLiteralSeparatorToNumberRector::class,
         CountArrayToEmptyArrayComparisonRector::class,
-        JsonThrowOnErrorRector::class,
         DisallowedEmptyRuleFixerRector::class,
     ]);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -24,8 +24,6 @@ class Client implements ClientContract
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
-    private ClientInterface $httpClient;
-
     /**
      * @throws ClientException
      * @throws ClusterApiException
@@ -33,7 +31,7 @@ class Client implements ClientContract
     public function __construct(
         private readonly Configuration $configuration,
         bool $manuallyAuthenticate = false,
-        ClientInterface $httpClient = null
+        private ?ClientInterface $httpClient = null
     ) {
         // Initialize the HTTP client
         $this->initHttpClient($httpClient);
@@ -52,21 +50,17 @@ class Client implements ClientContract
     /**
      * Initialize the HTTP client with default configuration which is used for every request.
      */
-    private function initHttpClient(ClientInterface $httpClient = null): void
+    private function initHttpClient(?ClientInterface $httpClient = null): void
     {
-        if ($httpClient instanceof ClientInterface) {
-            $this->httpClient = $httpClient;
-
-            return;
+        if (! $httpClient instanceof ClientInterface) {
+            $this->httpClient = new GuzzleClient([
+                'timeout' => self::TIMEOUT,
+                'connect_timeout' => self::CONNECT_TIMEOUT,
+                'headers' => [
+                    'User-Agent' => self::USER_AGENT,
+                ]
+            ]);
         }
-
-        $this->httpClient = new GuzzleClient([
-            'timeout' => self::TIMEOUT,
-            'connect_timeout' => self::CONNECT_TIMEOUT,
-            'headers' => [
-                'User-Agent' => self::USER_AGENT,
-            ]
-        ]);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,8 +19,8 @@ class Client implements ClientContract
     private const CONNECT_TIMEOUT = 60;
 
     private const TIMEOUT = 180;
-  
-    private const VERSION = '1.117.1';
+
+    private const VERSION = '1.118.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
@@ -31,7 +31,7 @@ class Client implements ClientContract
      * @throws ClusterApiException
      */
     public function __construct(
-        private Configuration $configuration,
+        private readonly Configuration $configuration,
         bool $manuallyAuthenticate = false,
         ClientInterface $httpClient = null
     ) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -52,7 +52,7 @@ class Client implements ClientContract
      */
     private function initHttpClient(?ClientInterface $httpClient = null): void
     {
-        if (! $httpClient instanceof ClientInterface) {
+        if (!$httpClient instanceof ClientInterface) {
             $this->httpClient = new GuzzleClient([
                 'timeout' => self::TIMEOUT,
                 'connect_timeout' => self::CONNECT_TIMEOUT,

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -54,7 +54,7 @@ use Cyberfusion\ClusterApi\Endpoints\VirtualHosts;
 
 class ClusterApi
 {
-    public function __construct(private ClientContract $client)
+    public function __construct(private readonly ClientContract $client)
     {
     }
 

--- a/src/Endpoints/CertificateManagers.php
+++ b/src/Endpoints/CertificateManagers.php
@@ -142,27 +142,6 @@ class CertificateManagers extends Endpoint
     /**
      * @throws RequestException
      */
-    public function restore(int $id): Response
-    {
-        $request = (new Request())
-            ->setMethod(Request::METHOD_POST)
-            ->setUrl(sprintf('certificate-managers/%d/restore', $id));
-
-        $response = $this
-            ->client
-            ->request($request);
-        if (!$response->isSuccess()) {
-            return $response;
-        }
-
-        return $response->setData([
-            'certificateManager' => (new CertificateManager())->fromArray($response->getData()),
-        ]);
-    }
-
-    /**
-     * @throws RequestException
-     */
     public function delete(int $id): Response
     {
         $request = (new Request())

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -10,10 +10,12 @@ use Cyberfusion\ClusterApi\Models\HostIpAddress;
 use Cyberfusion\ClusterApi\Models\IpAddressCreate;
 use Cyberfusion\ClusterApi\Models\IpAddressProduct;
 use Cyberfusion\ClusterApi\Models\TaskCollection;
+use Cyberfusion\ClusterApi\Models\TaskResult;
 use Cyberfusion\ClusterApi\Models\UnixUsersHomeDirectoryUsage;
 use Cyberfusion\ClusterApi\Request;
 use Cyberfusion\ClusterApi\Response;
 use Cyberfusion\ClusterApi\Support\ListFilter;
+use Cyberfusion\ClusterApi\Support\Str;
 use DateTimeInterface;
 
 class Clusters extends Endpoint
@@ -76,6 +78,7 @@ class Clusters extends Endpoint
             'groups',
             'unix_users_home_directory',
             'php_versions',
+            'load_balancing_method',
             'mariadb_version',
             'mariadb_cluster_name',
             'php_settings',
@@ -132,6 +135,7 @@ class Clusters extends Endpoint
                     'groups',
                     'unix_users_home_directory',
                     'php_versions',
+                    'load_balancing_method',
                     'mariadb_version',
                     'mariadb_cluster_name',
                     'php_settings',
@@ -203,6 +207,7 @@ class Clusters extends Endpoint
             'groups',
             'unix_users_home_directory',
             'php_versions',
+            'load_balancing_method',
             'mariadb_version',
             'mariadb_cluster_name',
             'php_settings',
@@ -262,6 +267,7 @@ class Clusters extends Endpoint
                     'groups',
                     'unix_users_home_directory',
                     'php_versions',
+                    'load_balancing_method',
                     'mariadb_version',
                     'mariadb_cluster_name',
                     'php_settings',
@@ -519,6 +525,33 @@ class Clusters extends Endpoint
             'ipAddressProducts' => array_map(
                 fn (array $data) => (new IpAddressProduct())->fromArray($data),
                 $response->getData()
+            ),
+        ]);
+    }
+
+    public function deploymentResults(int $id, bool $nonRunning = false): Response
+    {
+        $url = Str::optionalQueryParameters(
+            sprintf('clusters/%s/deployment-results', $id),
+            ['get_non_running' => $nonRunning]
+        );
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl($url);
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'created_at' => $response->getData('created_at'),
+            'taskResults' => array_map(
+                fn (array $data) => (new TaskResult())->fromArray($data),
+                $response->getData('tasks_results')
             ),
         ]);
     }

--- a/src/Endpoints/Cmses.php
+++ b/src/Endpoints/Cmses.php
@@ -8,6 +8,7 @@ use Cyberfusion\ClusterApi\Models\CmsConfigurationConstant;
 use Cyberfusion\ClusterApi\Models\CmsInstallation;
 use Cyberfusion\ClusterApi\Models\CmsOption;
 use Cyberfusion\ClusterApi\Models\CmsUserCredentials;
+use Cyberfusion\ClusterApi\Models\DetailMessage;
 use Cyberfusion\ClusterApi\Models\TaskCollection;
 use Cyberfusion\ClusterApi\Request;
 use Cyberfusion\ClusterApi\Response;
@@ -285,8 +286,8 @@ class Cmses extends Endpoint
             ->setUrl(sprintf('cmses/%d/configuration-constants/%d', $id, $cmsConfigurationConstant->getName()))
             ->setBody(
                 $this->filterFields($cmsConfigurationConstant->toArray(), [
-                    'name',
                     'value',
+                    'index',
                 ])
             );
 
@@ -431,5 +432,99 @@ class Cmses extends Endpoint
         }
 
         return null;
+    }
+
+    public function plugins(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('cmses/%d/plugins', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'plugins' => $response->getData(),
+        ]);
+    }
+
+    public function updateCore(int $id, ?string $callbackUrl = null): Response
+    {
+        $url = Str::optionalQueryParameters(
+            sprintf('cmses/%d/core/update', $id),
+            ['callback_url' => $callbackUrl]
+        );
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl($url);
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'taskCollection' => (new TaskCollection())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function updatePlugin(int $id, string $name, ?string $callbackUrl = null): Response
+    {
+        $url = Str::optionalQueryParameters(
+            sprintf('cmses/%d/plugins/%s/update', $id, $name),
+            ['callback_url' => $callbackUrl]
+        );
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl($url);
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'taskCollection' => (new TaskCollection())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function enablePlugin(int $id, string $name): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl(sprintf('cmses/%d/plugins/%s/enable', $id, $name));
+
+        $response = $this
+            ->client
+            ->request($request);
+
+        return $response->setData([
+            'detail' => (new DetailMessage())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function disablePlugin(int $id, string $name): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl(sprintf('cmses/%d/plugins/%s/disable', $id, $name));
+
+        $response = $this
+            ->client
+            ->request($request);
+
+        return $response->setData([
+            'detail' => (new DetailMessage())->fromArray($response->getData()),
+        ]);
     }
 }

--- a/src/Endpoints/HAProxyListens.php
+++ b/src/Endpoints/HAProxyListens.php
@@ -70,6 +70,7 @@ class HAProxyListens extends Endpoint
             'nodes_ids',
             'port',
             'socket_path',
+            'load_balancing_method',
             'destination_cluster_id',
             'cluster_id',
         ]);
@@ -84,6 +85,7 @@ class HAProxyListens extends Endpoint
                     'nodes_ids',
                     'port',
                     'socket_path',
+                    'load_balancing_method',
                     'destination_cluster_id',
                     'cluster_id',
                 ])

--- a/src/Enums/CmsConfigurationConstantName.php
+++ b/src/Enums/CmsConfigurationConstantName.php
@@ -2,6 +2,9 @@
 
 namespace Cyberfusion\ClusterApi\Enums;
 
+/*
+ * @deprecated see 1.231
+ */
 class CmsConfigurationConstantName
 {
     public const DB_NAME = 'DB_NAME';

--- a/src/Enums/FirewallRuleExternalProviderName.php
+++ b/src/Enums/FirewallRuleExternalProviderName.php
@@ -5,11 +5,13 @@ namespace Cyberfusion\ClusterApi\Enums;
 class FirewallRuleExternalProviderName
 {
     public const ATLASSIAN = 'Atlassian';
+    public const AWS = 'AWS';
     public const BUDDY = 'Buddy';
     public const GOOGLE_CLOUD = 'Google Cloud';
 
     public const AVAILABLE = [
         self::ATLASSIAN,
+        self::AWS,
         self::BUDDY,
         self::GOOGLE_CLOUD,
     ];

--- a/src/Enums/NodeGroup.php
+++ b/src/Enums/NodeGroup.php
@@ -7,6 +7,7 @@ class NodeGroup
     public const ADMIN = 'Admin';
     public const APACHE = 'Apache';
     public const BORG = 'Borg';
+    public const CLAM_AV = 'ClamAV';
     public const COMPOSER = 'Composer';
     public const DOCKER = 'Docker';
     public const DOVECOT = 'Dovecot';
@@ -41,6 +42,7 @@ class NodeGroup
         self::ADMIN,
         self::APACHE,
         self::BORG,
+        self::CLAM_AV,
         self::COMPOSER,
         self::DOCKER,
         self::DOVECOT,

--- a/src/Exceptions/ClientException.php
+++ b/src/Exceptions/ClientException.php
@@ -6,7 +6,7 @@ use Throwable;
 
 class ClientException extends ClusterApiException
 {
-    public static function authenticationMissing(Throwable $previous = null): self
+    public static function authenticationMissing(?Throwable $previous = null): self
     {
         return new self(
             'Missing information to authenticate, please provide an access token or the credentials',
@@ -15,7 +15,7 @@ class ClientException extends ClusterApiException
         );
     }
 
-    public static function invalidCredentials(Throwable $previous = null): self
+    public static function invalidCredentials(?Throwable $previous = null): self
     {
         return new self(
             'The provided credentials are invalid, please check the username and password',
@@ -24,7 +24,7 @@ class ClientException extends ClusterApiException
         );
     }
 
-    public static function authenticationFailed(Throwable $previous = null): self
+    public static function authenticationFailed(?Throwable $previous = null): self
     {
         return new self(
             'Failed to authenticate',
@@ -33,7 +33,7 @@ class ClientException extends ClusterApiException
         );
     }
 
-    public static function apiNotUp(Throwable $previous = null): self
+    public static function apiNotUp(?Throwable $previous = null): self
     {
         return new self(
             'The API is not available at this moment',

--- a/src/Exceptions/ListFilterException.php
+++ b/src/Exceptions/ListFilterException.php
@@ -6,7 +6,7 @@ use Throwable;
 
 class ListFilterException extends ClusterApiException
 {
-    public static function invalidModel(Throwable $previous = null): self
+    public static function invalidModel(?Throwable $previous = null): self
     {
         return new self(
             'The provided model can\'t be use for a filter, the model must implement the `Model` contract',
@@ -15,7 +15,7 @@ class ListFilterException extends ClusterApiException
         );
     }
 
-    public static function unableToDetermineFields(Throwable $previous = null): self
+    public static function unableToDetermineFields(?Throwable $previous = null): self
     {
         return new self(
             'Unable to get the available fields for the model',
@@ -26,7 +26,7 @@ class ListFilterException extends ClusterApiException
 
     public static function invalidSortMethod(
         string $providedSortMethod,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ): self {
         return new self(
             sprintf('The sort method `%s` is not available, use ASC or DESC', $providedSortMethod),
@@ -35,7 +35,7 @@ class ListFilterException extends ClusterApiException
         );
     }
 
-    public static function fieldNotAvailable(string $field, Throwable $previous = null): self
+    public static function fieldNotAvailable(string $field, ?Throwable $previous = null): self
     {
         return new self(
             sprintf('The field `%s` is not available in the model', $field),
@@ -44,7 +44,7 @@ class ListFilterException extends ClusterApiException
         );
     }
 
-    public static function invalidTypeInArray(string $foundType, Throwable $previous = null): self
+    public static function invalidTypeInArray(string $foundType, ?Throwable $previous = null): self
     {
         return new self(
             sprintf(
@@ -56,7 +56,7 @@ class ListFilterException extends ClusterApiException
         );
     }
 
-    public static function arrayEntryKeysInvalid(array $requiredKeys, Throwable $previous = null): self
+    public static function arrayEntryKeysInvalid(array $requiredKeys, ?Throwable $previous = null): self
     {
         return new self(
             sprintf(

--- a/src/Exceptions/ModelException.php
+++ b/src/Exceptions/ModelException.php
@@ -6,7 +6,7 @@ use Throwable;
 
 class ModelException extends ClusterApiException
 {
-    public static function propertyNotAvailable(string $property, Throwable $previous = null): self
+    public static function propertyNotAvailable(string $property, ?Throwable $previous = null): self
     {
         return new self(
             sprintf('The property `%s` is not available for this model', $property),

--- a/src/Exceptions/RequestException.php
+++ b/src/Exceptions/RequestException.php
@@ -6,7 +6,7 @@ use Throwable;
 
 class RequestException extends ClusterApiException
 {
-    public static function authenticationRequired(Throwable $previous = null): self
+    public static function authenticationRequired(?Throwable $previous = null): self
     {
         return new self(
             'The request requires authentication, login before making this request',
@@ -15,7 +15,7 @@ class RequestException extends ClusterApiException
         );
     }
 
-    public static function requestFailed(string $message, Throwable $previous = null): self
+    public static function requestFailed(string $message, ?Throwable $previous = null): self
     {
         return new self(
             sprintf('Request failed, error: `%s`', $message),
@@ -28,7 +28,7 @@ class RequestException extends ClusterApiException
         string $type,
         string $action,
         array $missing,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ): self {
         return new self(
             sprintf(

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -6,7 +6,7 @@ use Throwable;
 
 class ValidationException extends ClusterApiException
 {
-    public static function validationFailed(array $failedValidations = [], Throwable $previous = null): self
+    public static function validationFailed(array $failedValidations = [], ?Throwable $previous = null): self
     {
         return new self(
             sprintf('The validation failed: `%s`', implode(', ', $failedValidations)),

--- a/src/Models/BorgArchiveMetadata.php
+++ b/src/Models/BorgArchiveMetadata.php
@@ -6,9 +6,23 @@ use Cyberfusion\ClusterApi\Support\Arr;
 
 class BorgArchiveMetadata extends ClusterModel
 {
+    private string $name;
     private string $contentsPath;
     private bool $existsOnServer;
     private int $borgArchiveId;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
 
     public function getContentsPath(): string
     {
@@ -49,6 +63,7 @@ class BorgArchiveMetadata extends ClusterModel
     public function fromArray(array $data): self
     {
         return $this
+            ->setName(Arr::get($data, 'name'))
             ->setContentsPath(Arr::get($data, 'contents_path'))
             ->setExistsOnServer(Arr::get($data, 'exists_on_server'))
             ->setBorgArchiveId(Arr::get($data, 'borg_archive_id'));
@@ -57,6 +72,7 @@ class BorgArchiveMetadata extends ClusterModel
     public function toArray(): array
     {
         return [
+            'name' => $this->getName(),
             'contents_path' => $this->getContentsPath(),
             'exists_on_server' => $this->getExistsOnServer(),
             'borg_archive_id' => $this->getBorgArchiveId(),

--- a/src/Models/BorgRepository.php
+++ b/src/Models/BorgRepository.php
@@ -64,7 +64,7 @@ class BorgRepository extends ClusterModel
         return $this->keepHourly;
     }
 
-    public function setKeepHourly(int $keepHourly = null): self
+    public function setKeepHourly(?int $keepHourly = null): self
     {
         $this->keepHourly = $keepHourly;
 
@@ -76,7 +76,7 @@ class BorgRepository extends ClusterModel
         return $this->keepDaily;
     }
 
-    public function setKeepDaily(int $keepDaily = null): self
+    public function setKeepDaily(?int $keepDaily = null): self
     {
         $this->keepDaily = $keepDaily;
 
@@ -88,7 +88,7 @@ class BorgRepository extends ClusterModel
         return $this->keepWeekly;
     }
 
-    public function setKeepWeekly(int $keepWeekly = null): self
+    public function setKeepWeekly(?int $keepWeekly = null): self
     {
         $this->keepWeekly = $keepWeekly;
 
@@ -100,7 +100,7 @@ class BorgRepository extends ClusterModel
         return $this->keepMonthly;
     }
 
-    public function setKeepMonthly(int $keepMonthly = null): self
+    public function setKeepMonthly(?int $keepMonthly = null): self
     {
         $this->keepMonthly = $keepMonthly;
 
@@ -112,7 +112,7 @@ class BorgRepository extends ClusterModel
         return $this->keepYearly;
     }
 
-    public function setKeepYearly(int $keepYearly = null): self
+    public function setKeepYearly(?int $keepYearly = null): self
     {
         $this->keepYearly = $keepYearly;
 

--- a/src/Models/CertificateManager.php
+++ b/src/Models/CertificateManager.php
@@ -18,7 +18,6 @@ class CertificateManager extends ClusterModel
     private ?string $lastRequestTaskCollectionUuid = null;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
-    private ?string $deletedAt = null;
 
     public function getMainCommonName(): ?string
     {
@@ -148,17 +147,6 @@ class CertificateManager extends ClusterModel
         return $this;
     }
 
-    public function getDeletedAt(): ?string
-    {
-        return $this->deletedAt;
-    }
-
-    public function setDeletedAt(?string $deletedAt): self
-    {
-        $this->deletedAt = $deletedAt;
-        return $this;
-    }
-
     public function fromArray(array $data): self
     {
         return $this
@@ -171,8 +159,7 @@ class CertificateManager extends ClusterModel
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
-            ->setUpdatedAt(Arr::get($data, 'updated_at'))
-            ->setDeletedAt(Arr::get($data, 'deleted_at'));
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
@@ -188,7 +175,6 @@ class CertificateManager extends ClusterModel
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),
             'updated_at' => $this->getUpdatedAt(),
-            'deleted_at' => $this->getDeletedAt(),
         ];
     }
 }

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -17,6 +17,7 @@ class Cluster extends ClusterModel
     private ?string $mariaDbClusterName = null;
     private array $customPhpModulesNames = [];
     private array $phpSettings = [];
+    private ?string $loadBalancingMethod = null;
     private ?array $httpRetryProperties = null;
     private ?bool $phpIoncubeEnabled = null;
     private ?string $kernelcareLicenseKey = null;
@@ -165,6 +166,18 @@ class Cluster extends ClusterModel
     public function setPhpSettings(array $phpSettings): self
     {
         $this->phpSettings = $phpSettings;
+
+        return $this;
+    }
+
+    public function getLoadBalancingMethod(): ?string
+    {
+        return $this->loadBalancingMethod;
+    }
+
+    public function setLoadBalancingMethod(?string $loadBalancingMethod): self
+    {
+        $this->loadBalancingMethod = $loadBalancingMethod;
 
         return $this;
     }
@@ -786,6 +799,7 @@ class Cluster extends ClusterModel
             ->setMariaDbClusterName(Arr::get($data, 'mariadb_cluster_name'))
             ->setCustomPhpModulesNames(Arr::get($data, 'custom_php_modules_names', []))
             ->setPhpSettings(Arr::get($data, 'php_settings', []))
+            ->setLoadBalancingMethod(Arr::get($data, 'load_balancing_method'))
             ->setHttpRetryProperties(Arr::get($data, 'http_retry_properties'))
             ->setPhpIoncubeEnabled(Arr::get($data, 'php_ioncube_enabled'))
             ->setKernelcareLicenseKey(Arr::get($data, 'kernelcare_license_key'))
@@ -843,6 +857,7 @@ class Cluster extends ClusterModel
             'mariadb_version' => $this->getMariaDbVersion(),
             'mariadb_cluster_name' => $this->getMariaDbClusterName(),
             'php_settings' => new ArrayObject($this->getPhpSettings()),
+            'load_balancing_method' => $this->getLoadBalancingMethod(),
             'http_retry_properties' => $this->getHttpRetryProperties()
                 ? new ArrayObject($this->getHttpRetryProperties())
                 : null,

--- a/src/Models/CmsConfigurationConstant.php
+++ b/src/Models/CmsConfigurationConstant.php
@@ -2,7 +2,6 @@
 
 namespace Cyberfusion\ClusterApi\Models;
 
-use Cyberfusion\ClusterApi\Enums\CmsConfigurationConstantName;
 use Cyberfusion\ClusterApi\Exceptions\ValidationException;
 use Cyberfusion\ClusterApi\Support\Arr;
 use Cyberfusion\ClusterApi\Support\Validator;
@@ -11,6 +10,7 @@ class CmsConfigurationConstant extends ClusterModel
 {
     private string $name;
     private mixed $value;
+    private ?int $index = null;
 
     public function getName(): string
     {
@@ -20,7 +20,6 @@ class CmsConfigurationConstant extends ClusterModel
     public function setName(string $name): self
     {
         Validator::value($name)
-            ->valueIn(CmsConfigurationConstantName::AVAILABLE)
             ->maxLength(255)
             ->validate();
 
@@ -49,11 +48,24 @@ class CmsConfigurationConstant extends ClusterModel
         return $this;
     }
 
+    public function getIndex(): ?int
+    {
+        return $this->index;
+    }
+
+    public function setIndex(?int $index = null): self
+    {
+        $this->index = $index;
+
+        return $this;
+    }
+
     public function fromArray(array $data): self
     {
         return $this
             ->setName(Arr::get($data, 'name'))
-            ->setValue(Arr::get($data, 'value'));
+            ->setValue(Arr::get($data, 'value'))
+            ->setIndex(Arr::get($data, 'index'));
     }
 
     public function toArray(): array
@@ -61,6 +73,7 @@ class CmsConfigurationConstant extends ClusterModel
         return [
             'name' => $this->getName(),
             'value' => $this->getValue(),
+            'index' => $this->index,
         ];
     }
 }

--- a/src/Models/HAProxyListen.php
+++ b/src/Models/HAProxyListen.php
@@ -19,6 +19,8 @@ class HAProxyListen extends ClusterModel
 
     private ?string $socketPath = null;
 
+    private ?string $loadBalancingMethod = null;
+
     private int $destinationClusterId;
 
     private int $clusterId;
@@ -111,6 +113,18 @@ class HAProxyListen extends ClusterModel
         return $this;
     }
 
+    public function getLoadBalancingMethod(): ?string
+    {
+        return $this->loadBalancingMethod;
+    }
+
+    public function setLoadBalancingMethod(?string $loadBalancingMethod): self
+    {
+        $this->loadBalancingMethod = $loadBalancingMethod;
+
+        return $this;
+    }
+
     public function getDestinationClusterId(): int
     {
         return $this->destinationClusterId;
@@ -179,6 +193,7 @@ class HAProxyListen extends ClusterModel
             ->setNodesIds(Arr::get($data, 'nodes_ids'))
             ->setPort(Arr::get($data, 'port'))
             ->setSocketPath(Arr::get($data, 'socket_path'))
+            ->setLoadBalancingMethod(Arr::get($data, 'load_balancing_method'))
             ->setDestinationClusterId(Arr::get($data, 'destination_cluster_id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setId(Arr::get($data, 'id'))
@@ -194,6 +209,7 @@ class HAProxyListen extends ClusterModel
             'nodes_ids' => $this->getNodesIds(),
             'port' => $this->getPort(),
             'socket_path' => $this->getSocketPath(),
+            'load_balancing_method' => $this->getLoadBalancingMethod(),
             'destination_cluster_id' => $this->getDestinationClusterId(),
             'cluster_id' => $this->getClusterId(),
             'id' => $this->getId(),

--- a/src/Models/HAProxyListen.php
+++ b/src/Models/HAProxyListen.php
@@ -82,7 +82,7 @@ class HAProxyListen extends ClusterModel
         return $this->port;
     }
 
-    public function setPort(int $port = null): self
+    public function setPort(?int $port = null): self
     {
         Validator::value($port)
             ->nullable()

--- a/src/Models/TaskCollection.php
+++ b/src/Models/TaskCollection.php
@@ -13,6 +13,7 @@ class TaskCollection extends ClusterModel
     private string $collectionType;
     private ?int $objectId = null;
     private string $objectModelName;
+    private ?string $reference = null;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -87,6 +88,18 @@ class TaskCollection extends ClusterModel
         return $this;
     }
 
+    public function getReference(): ?string
+    {
+        return $this->reference;
+    }
+
+    public function setReference(?string $reference): self
+    {
+        $this->reference = $reference;
+
+        return $this;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -139,10 +152,11 @@ class TaskCollection extends ClusterModel
     {
         return $this
             ->setUuid(Arr::get($data, 'uuid'))
-            ->setDescription(Arr::get($data, 'description'))
-            ->setCollectionType(Arr::get($data, 'collection_type'))
+            ->setDescription(Arr::get($data, 'description', ''))
+            ->setCollectionType(Arr::get($data, 'collection_type', TaskCollectionType::TYPE_ASYNCHRONOUS))
             ->setObjectId(Arr::get($data, 'object_id'))
             ->setObjectModelName(Arr::get($data, 'object_model_name'))
+            ->setReference(Arr::get($data, 'reference'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -157,6 +171,7 @@ class TaskCollection extends ClusterModel
             'collection_type' => $this->getCollectionType(),
             'object_id' => $this->getObjectId(),
             'object_model_name' => $this->getObjectModelName(),
+            'reference' => $this->getReference(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Response.php
+++ b/src/Response.php
@@ -4,7 +4,7 @@ namespace Cyberfusion\ClusterApi;
 
 class Response
 {
-    public function __construct(private int $statusCode, private string $statusMessage, private array $data = [])
+    public function __construct(private readonly int $statusCode, private readonly string $statusMessage, private array $data = [])
     {
     }
 

--- a/src/Support/LogFilter.php
+++ b/src/Support/LogFilter.php
@@ -13,7 +13,6 @@ class LogFilter implements Filter
     private ?DateTimeInterface $timestamp = null;
     private int $limit = Limit::DEFAULT_LIMIT;
     private string $sort = Sort::ASC;
-    private bool $showRawMessage = false;
 
     public function getTimestamp(): ?DateTimeInterface
     {
@@ -59,25 +58,12 @@ class LogFilter implements Filter
         return $this;
     }
 
-    public function isShowRawMessage(): bool
-    {
-        return $this->showRawMessage;
-    }
-
-    public function setShowRawMessage(bool $showRawMessage): self
-    {
-        $this->showRawMessage = $showRawMessage;
-
-        return $this;
-    }
-
     public function toQuery(): string
     {
         return http_build_query([
             'timestamp' => $this->timestamp instanceof DateTimeInterface ? $this->timestamp->format('c') : null,
             'limit' => $this->limit,
             'sort' => $this->sort,
-            'show_raw_message' => $this->showRawMessage,
         ]);
     }
 }

--- a/src/Support/Validator.php
+++ b/src/Support/Validator.php
@@ -29,7 +29,7 @@ class Validator
         return new self($value);
     }
 
-    private function __construct(private mixed $value)
+    private function __construct(private readonly mixed $value)
     {
     }
 

--- a/tests/Support/LogFilterTest.php
+++ b/tests/Support/LogFilterTest.php
@@ -9,48 +9,42 @@ use PHPUnit\Framework\TestCase;
 
 class LogFilterTest extends TestCase
 {
-    public function testLogFilterDefaults()
+    public function testLogFilterDefaults(): void
     {
         $logFilter = new LogFilter();
 
         $this->assertNull($logFilter->getTimestamp());
         $this->assertSame(100, $logFilter->getLimit());
-        $this->assertFalse($logFilter->isShowRawMessage());
         $this->assertSame(Sort::ASC, $logFilter->getSort());
     }
 
-    public function testLogFilter()
+    public function testLogFilter(): void
     {
         $timestamp = Carbon::today()->subDay();
         $limit = 100;
-        $showRawMessage = true;
 
         $logFilter = (new LogFilter())
             ->setTimestamp($timestamp)
             ->setLimit($limit)
-            ->setShowRawMessage($showRawMessage)
             ->setSort(Sort::DESC);
 
         $this->assertSame($timestamp->format('c'), $logFilter->getTimestamp()->format('c'));
         $this->assertSame(100, $logFilter->getLimit());
-        $this->assertSame($showRawMessage, $logFilter->isShowRawMessage());
         $this->assertSame(Sort::DESC, $logFilter->getSort());
     }
 
-    public function testToQuery()
+    public function testToQuery(): void
     {
         $timestamp = Carbon::today()->subDay();
         $limit = 100;
-        $showRawMessage = true;
 
         $logFilter = (new LogFilter())
             ->setTimestamp($timestamp)
             ->setLimit($limit)
-            ->setShowRawMessage($showRawMessage)
             ->setSort(Sort::DESC);
 
         $this->assertSame(
-            'timestamp=' . $timestamp->format('Y-m-d') . 'T00%3A00%3A00%2B00%3A00&limit=100&sort=DESC&show_raw_message=1',
+            'timestamp=' . $timestamp->format('Y-m-d') . 'T00%3A00%3A00%2B00%3A00&limit=100&sort=DESC',
             $logFilter->toQuery()
         );
     }


### PR DESCRIPTION
# Changes

### Added

- Add NextCloud endpoints.
- Add `index` property to `CmsConfigurationContstant` and add it to the request body.
- Add plugin methods to CMSes endpoint.
- Add `reference` property to the `TaskCollection` model.
- Add `deploymentResults` method to the `Cluster` endpoint.
- Add `ClamAV` as node group.
- Add `AWS` as option for the `external_provider_name` property of the `FirewallRule` model.
- Add `name` property to the `BorgArchiveMetadata` model.
- Add `load_balancing_method` property to the `Cluster` model.
- Add `load_balancing_method` property to the `HAProxyListen` model.
- Add compatibility for this client for PHP 8.4.

### Changed

- Update to [API version 1.238.0](https://core-api.cyberfusion.io/redoc#section/Changelog/1.238.0-2024-12-27).

### Fixed

- Fix task collection return when just the `task_collection_uuid` is returned.

### Removed

- Removed the `show_raw_message` parameter from the LogFilter as the raw message is now always returned.
- Removed the `restore` method of the `CertificateManagers` endpoint as Certificate Manager are no longer soft-deleted.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Core API version is updated in the README (when applicable)
