### PR TITLE
Allow the host of the database user to be `null` to match the Core API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.118.1]
+
+### Fixed
+
+- Allow the host of the database user to be `null` to match the Core API spec.
+
 ## [1.118.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.118.0';
+    private const VERSION = '1.118.1';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Models/DatabaseUser.php
+++ b/src/Models/DatabaseUser.php
@@ -14,7 +14,7 @@ class DatabaseUser extends ClusterModel
     private string $name;
     private ?string $password;
     private ?array $phpmyadminFirewallGroupsIds = null;
-    private string $host = self::DEFAULT_HOST;
+    private ?string $host = self::DEFAULT_HOST;
     private string $serverSoftwareName = DatabaseEngine::SERVER_SOFTWARE_MARIADB;
     private ?int $id = null;
     private ?int $clusterId = null;
@@ -38,16 +38,17 @@ class DatabaseUser extends ClusterModel
         return $this;
     }
 
-    public function getHost(): string
+    public function getHost(): ?string
     {
         return $this->host;
     }
 
-    public function setHost(string $host): self
+    public function setHost(?string $host): self
     {
         Validator::value($host)
             ->maxLength(253)
             ->valueIn(Host::AVAILABLE)
+            ->nullable()
             ->validate();
 
         $this->host = $host;


### PR DESCRIPTION
# Changes

### Fixed

- Allow the host of the database user to be `null` to match the Core API spec.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Core API version is updated in the README (when applicable)
