### PR TITLE
Add support for Laravel 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.119.0]
+
+### Added
+
+- Add support for Laravel 12.
+
 ## [1.118.1]
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
         "php": "^8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
-        "illuminate/support": "^8.22 || ^9.0 || ^10.0 || ^11.0",
-        "ramsey/uuid": "^3.9 || ^4.0",
+        "illuminate/support": "^8.22|^9.0|^10.0|^11.0|^12.0",
+        "ramsey/uuid": "^3.9|^4.0",
         "vdhicts/http-query-builder": "^1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.2",
-        "phpunit/phpunit": "^9.6 || 10.0",
-        "rector/rector": "^1.0.0",
+        "phpstan/phpstan": "^1.2|^2.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
+        "rector/rector": "^1.0|^2.0",
         "symplify/easy-coding-standard": "^12.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <html outputDirectory="./build/report/"/>
     </report>
@@ -13,4 +10,9 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.118.1';
+    private const VERSION = '1.119.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/tests/Support/ListFilterTest.php
+++ b/tests/Support/ListFilterTest.php
@@ -15,9 +15,7 @@ class ListFilterTest extends TestCase
 
         $this->assertSame(0, $listFilter->getSkip());
         $this->assertSame(100, $listFilter->getLimit());
-        $this->assertIsArray($listFilter->getFilter());
         $this->assertCount(0, $listFilter->getFilter());
-        $this->assertIsArray($listFilter->getSort());
         $this->assertCount(0, $listFilter->getSort());
     }
 
@@ -40,9 +38,7 @@ class ListFilterTest extends TestCase
 
         $this->assertSame($skip, $listFilter->getSkip());
         $this->assertSame($limit, $listFilter->getLimit());
-        $this->assertIsArray($listFilter->getFilter());
         $this->assertCount(1, $listFilter->getFilter());
-        $this->assertIsArray($listFilter->getSort());
         $this->assertCount(1, $listFilter->getSort());
     }
 
@@ -90,9 +86,7 @@ class ListFilterTest extends TestCase
 
         $this->assertSame($skip, $listFilter->getSkip());
         $this->assertSame($limit, $listFilter->getLimit());
-        $this->assertIsArray($listFilter->getFilter());
         $this->assertCount(1, $listFilter->getFilter());
-        $this->assertIsArray($listFilter->getSort());
         $this->assertCount(1, $listFilter->getSort());
     }
 


### PR DESCRIPTION
# Changes

### Added

- Add support for Laravel 12.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Core API version is updated in the README (when applicable)
