### PR TITLE
Replace all PUT calls with PATCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.120.0]
+
+### Changed
+
+- Replace all PUT calls with PATCH.
+
 ## [1.119.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.119.0';
+    private const VERSION = '1.120.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Endpoints/BasicAuthenticationRealms.php
+++ b/src/Endpoints/BasicAuthenticationRealms.php
@@ -112,7 +112,7 @@ class BasicAuthenticationRealms extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('basic-authentication-realms/%d', $basicAuthenticationRealm->getId()))
             ->setBody(
                 $this->filterFields($basicAuthenticationRealm->toArray(), [

--- a/src/Endpoints/BorgRepositories.php
+++ b/src/Endpoints/BorgRepositories.php
@@ -131,7 +131,7 @@ class BorgRepositories extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('borg-repositories/%d', $borgRepository->getId()))
             ->setBody(
                 $this->filterFields($borgRepository->toArray(), [

--- a/src/Endpoints/CertificateManagers.php
+++ b/src/Endpoints/CertificateManagers.php
@@ -112,7 +112,7 @@ class CertificateManagers extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('certificate-managers/%d', $certificateManager->getId()))
             ->setBody(
                 $this->filterFields($certificateManager->toArray(), [

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -259,7 +259,7 @@ class Clusters extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('clusters/%d', $cluster->getId()))
             ->setBody(
                 $this->filterFields($cluster->toArray(), [

--- a/src/Endpoints/Cmses.php
+++ b/src/Endpoints/Cmses.php
@@ -248,7 +248,7 @@ class Cmses extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('cmses/%d/options/%d', $id, $cmsOption->getName()))
             ->setBody(
                 $this->filterFields($cmsOption->toArray(), [
@@ -282,7 +282,7 @@ class Cmses extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('cmses/%d/configuration-constants/%d', $id, $cmsConfigurationConstant->getName()))
             ->setBody(
                 $this->filterFields($cmsConfigurationConstant->toArray(), [

--- a/src/Endpoints/Crons.php
+++ b/src/Endpoints/Crons.php
@@ -120,7 +120,7 @@ class Crons extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('crons/%d', $cron->getId()))
             ->setBody(
                 $this->filterFields($cron->toArray(), [

--- a/src/Endpoints/CustomConfigSnippets.php
+++ b/src/Endpoints/CustomConfigSnippets.php
@@ -149,7 +149,7 @@ class CustomConfigSnippets extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('custom-config-snippets/%d', $customConfigSnippet->getId()))
             ->setBody(
                 $this->filterFields($customConfigSnippet->toArray(), [

--- a/src/Endpoints/CustomConfigs.php
+++ b/src/Endpoints/CustomConfigs.php
@@ -108,7 +108,7 @@ class CustomConfigs extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('custom-configs/%d', $customConfig->getId()))
             ->setBody(
                 $this->filterFields($customConfig->toArray(), [

--- a/src/Endpoints/Daemons.php
+++ b/src/Endpoints/Daemons.php
@@ -116,7 +116,7 @@ class Daemons extends Endpoint
         ]);
 
         $request = (new Request())
-          ->setMethod(Request::METHOD_PUT)
+          ->setMethod(Request::METHOD_PATCH)
           ->setUrl(sprintf('daemons/%d', $daemon->getId()))
           ->setBody(
               $this->filterFields($daemon->toArray(), [

--- a/src/Endpoints/DatabaseUsers.php
+++ b/src/Endpoints/DatabaseUsers.php
@@ -115,7 +115,7 @@ class DatabaseUsers extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('database-users/%d', $databaseUser->getId()))
             ->setBody(
                 $this->filterFields($databaseUser->toArray(), [

--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -118,7 +118,7 @@ class Databases extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('databases/%d', $database->getId()))
             ->setBody(
                 $this->filterFields($database->toArray(), [

--- a/src/Endpoints/DomainRouters.php
+++ b/src/Endpoints/DomainRouters.php
@@ -57,7 +57,7 @@ class DomainRouters extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('domain-routers/%d', $domainRouter->getId()))
             ->setBody(
                 $this->filterFields($domainRouter->toArray(), [

--- a/src/Endpoints/FirewallGroups.php
+++ b/src/Endpoints/FirewallGroups.php
@@ -106,7 +106,7 @@ class FirewallGroups extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('firewall-groups/%d', $firewallGroup->getId()))
             ->setBody(
                 $this->filterFields($firewallGroup->toArray(), [

--- a/src/Endpoints/FpmPools.php
+++ b/src/Endpoints/FpmPools.php
@@ -120,7 +120,7 @@ class FpmPools extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('fpm-pools/%d', $fpmPool->getId()))
             ->setBody(
                 $this->filterFields($fpmPool->toArray(), [

--- a/src/Endpoints/FtpUsers.php
+++ b/src/Endpoints/FtpUsers.php
@@ -111,7 +111,7 @@ class FtpUsers extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('ftp-users/%d', $ftpUser->getId()))
             ->setBody(
                 $this->filterFields($ftpUser->toArray(), [

--- a/src/Endpoints/HtpasswdUsers.php
+++ b/src/Endpoints/HtpasswdUsers.php
@@ -109,7 +109,7 @@ class HtpasswdUsers extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('htpasswd-users/%d', $htpasswdUser->getId()))
             ->setBody(
                 $this->filterFields($htpasswdUser->toArray(), [

--- a/src/Endpoints/MailAccounts.php
+++ b/src/Endpoints/MailAccounts.php
@@ -143,7 +143,7 @@ class MailAccounts extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('mail-accounts/%d', $mailAccount->getId()))
             ->setBody(
                 $this->filterFields($mailAccount->toArray(), [

--- a/src/Endpoints/MailAliases.php
+++ b/src/Endpoints/MailAliases.php
@@ -109,7 +109,7 @@ class MailAliases extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('mail-aliases/%d', $mailAlias->getId()))
             ->setBody(
                 $this->filterFields($mailAlias->toArray(), [

--- a/src/Endpoints/MailDomains.php
+++ b/src/Endpoints/MailDomains.php
@@ -110,7 +110,7 @@ class MailDomains extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('mail-domains/%d', $mailDomain->getId()))
             ->setBody(
                 $this->filterFields($mailDomain->toArray(), [

--- a/src/Endpoints/MailHostnames.php
+++ b/src/Endpoints/MailHostnames.php
@@ -106,7 +106,7 @@ class MailHostnames extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('mail-hostnames/%d', $mailHostname->getId()))
             ->setBody(
                 $this->filterFields($mailHostname->toArray(), [

--- a/src/Endpoints/Nodes.php
+++ b/src/Endpoints/Nodes.php
@@ -122,7 +122,7 @@ class Nodes extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('nodes/%d', $node->getId()))
             ->setBody(
                 $this->filterFields($node->toArray(), [

--- a/src/Endpoints/PassengerApps.php
+++ b/src/Endpoints/PassengerApps.php
@@ -125,7 +125,7 @@ class PassengerApps extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('passenger-apps/%d', $passengerApp->getId()))
             ->setBody(
                 $this->filterFields($passengerApp->toArray(), [

--- a/src/Endpoints/RedisInstances.php
+++ b/src/Endpoints/RedisInstances.php
@@ -112,7 +112,7 @@ class RedisInstances extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('redis-instances/%d', $redisInstance->getId()))
             ->setBody(
                 $this->filterFields($redisInstance->toArray(), [

--- a/src/Endpoints/SecurityTxtPolicies.php
+++ b/src/Endpoints/SecurityTxtPolicies.php
@@ -124,7 +124,7 @@ class SecurityTxtPolicies extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('security-txt-policies/%d', $securityTxtPolicy->getId()))
             ->setBody(
                 $this->filterFields($securityTxtPolicy->toArray(), [

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -156,7 +156,7 @@ class UnixUsers extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('unix-users/%d', $unixUser->getId()))
             ->setBody(
                 $this->filterFields($unixUser->toArray(), [

--- a/src/Endpoints/UrlRedirects.php
+++ b/src/Endpoints/UrlRedirects.php
@@ -121,7 +121,7 @@ class UrlRedirects extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('url-redirects/%d', $urlRedirect->getId()))
             ->setBody(
                 $this->filterFields($urlRedirect->toArray(), [

--- a/src/Endpoints/VirtualHosts.php
+++ b/src/Endpoints/VirtualHosts.php
@@ -125,7 +125,7 @@ class VirtualHosts extends Endpoint
         ]);
 
         $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
+            ->setMethod(Request::METHOD_PATCH)
             ->setUrl(sprintf('virtual-hosts/%d', $virtualHost->getId()))
             ->setBody(
                 $this->filterFields($virtualHost->toArray(), [


### PR DESCRIPTION
# Changes

- The deprecated PUT endpoints in the Core API will be removed.
- The new PHP client (https://github.com/CyberfusionIO/php-core-api-client) uses the new PATCH endpoints.
- Not all customers can upgrade to the new client within the timeframe that we want to remove the deprecated PUT endpoints in.
- Despite the fact that this client is deprecated, replace all PUT calls with PATCH - allowing us to remove the deprecated PUT endpoints from the Core API.
- Upgrading to the new client - which already uses the new PATCH endpoints - is still needed.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Core API version is updated in the README (when applicable)
