### PR TITLE
Partly add new cluster property models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the Core API. See the changelog of the [Core API](https://core-api.cyberfusion.io/redoc#section/Changelog) 
 for detailed information.
 
+## [1.121.0]
+
+### Added
+
+- Add `readPhpProperties`, `createPhpProperties` and `updatePhpProperties` method to the `Clusters` endpoint.
+- Add `readUnixUserProperties` method to the `Clusters` endpoint.
+- Add `readRedisProperties`, `createRedisProperties` and `updateRedisProperties` method to the `Clusters` endpoint.
+
 ## [1.120.0]
 
 ### Changed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '1.120.0';
+    private const VERSION = '1.121.0';
 
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -6,6 +6,9 @@ use Cyberfusion\ClusterApi\Enums\TimeUnit;
 use Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Cyberfusion\ClusterApi\Models\Cluster;
 use Cyberfusion\ClusterApi\Models\ClusterCommonProperties;
+use Cyberfusion\ClusterApi\Models\ClusterPhpProperties;
+use Cyberfusion\ClusterApi\Models\ClusterRedisProperties;
+use Cyberfusion\ClusterApi\Models\ClusterUnixUserProperties;
 use Cyberfusion\ClusterApi\Models\HostIpAddress;
 use Cyberfusion\ClusterApi\Models\IpAddressCreate;
 use Cyberfusion\ClusterApi\Models\IpAddressProduct;
@@ -553,6 +556,167 @@ class Clusters extends Endpoint
                 fn (array $data) => (new TaskResult())->fromArray($data),
                 $response->getData('tasks_results')
             ),
+        ]);
+    }
+
+    public function readPhpProperties(int $clusterId): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('clusters/%d/properties/php', $clusterId));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'properties' => (new ClusterPhpProperties())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function createPhpProperties(int $clusterId, ClusterPhpProperties $properties): Response
+    {
+        $this->validateRequired($properties, 'create', [
+            'php_versions',
+            'custom_php_modules_names',
+            'php_settings',
+            'php_ioncube_enabled',
+            'php_sessions_spread_enabled',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl(sprintf('clusters/%d/properties/php', $clusterId))
+            ->setBody($this->filterFields($properties->toArray(), [
+                'php_versions',
+                'custom_php_modules_names',
+                'php_settings',
+                'php_ioncube_enabled',
+                'php_sessions_spread_enabled',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'properties' => (new ClusterPhpProperties())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function updatePhpProperties(int $clusterId, ClusterPhpProperties $properties): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PATCH)
+            ->setUrl(sprintf('clusters/%d/properties/php', $clusterId))
+            ->setBody($this->filterFields($properties->toArray(), [
+                'php_versions',
+                'custom_php_modules_names',
+                'php_settings',
+                'php_ioncube_enabled',
+                'php_sessions_spread_enabled',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'properties' => (new ClusterPhpProperties())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function readUnixUserProperties(int $clusterId): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('clusters/%d/properties/unix-users', $clusterId));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'properties' => (new ClusterUnixUserProperties())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function readRedisProperties(int $clusterId): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('clusters/%d/properties/redis', $clusterId));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'properties' => (new ClusterRedisProperties())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function createRedisProperties(int $clusterId, ClusterRedisProperties $properties): Response
+    {
+        $this->validateRequired($properties, 'create', [
+            'redis_password',
+            'redis_memory_limit',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl(sprintf('clusters/%d/properties/redis', $clusterId))
+            ->setBody($this->filterFields($properties->toArray(), [
+                'redis_password',
+                'redis_memory_limit',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'properties' => (new ClusterRedisProperties())->fromArray($response->getData()),
+        ]);
+    }
+
+    public function updateRedisProperties(int $clusterId, ClusterRedisProperties $properties): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PATCH)
+            ->setUrl(sprintf('clusters/%d/properties/redis', $clusterId))
+            ->setBody($this->filterFields($properties->toArray(), [
+                'redis_password',
+                'redis_memory_limit',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'properties' => (new ClusterRedisProperties())->fromArray($response->getData()),
         ]);
     }
 }

--- a/src/Models/ClusterPhpProperties.php
+++ b/src/Models/ClusterPhpProperties.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use ArrayObject;
+use Cyberfusion\ClusterApi\Support\Arr;
+
+class ClusterPhpProperties extends ClusterModel
+{
+    private ?int $id = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+    private array $phpVersions = [];
+    private array $customPhpModulesNames = [];
+    private array $phpSettings = [];
+    private ?bool $phpIoncubeEnabled = null;
+    private ?bool $phpSessionSpreadEnabled = null;
+    private ?int $clusterId = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getPhpVersions(): array
+    {
+        return $this->phpVersions;
+    }
+
+    public function setPhpVersions(array $phpVersions): self
+    {
+        $this->phpVersions = $phpVersions;
+
+        return $this;
+    }
+
+    public function getCustomPhpModulesNames(): array
+    {
+        return $this->customPhpModulesNames;
+    }
+
+    public function setCustomPhpModulesNames(array $customPhpModulesNames): self
+    {
+        $this->customPhpModulesNames = $customPhpModulesNames;
+
+        return $this;
+    }
+
+    public function getPhpSettings(): array
+    {
+        return $this->phpSettings;
+    }
+
+    public function setPhpSettings(array $phpSettings): self
+    {
+        $this->phpSettings = $phpSettings;
+
+        return $this;
+    }
+
+    public function isPhpIoncubeEnabled(): ?bool
+    {
+        return $this->phpIoncubeEnabled;
+    }
+
+    public function setPhpIoncubeEnabled(?bool $phpIoncubeEnabled): self
+    {
+        $this->phpIoncubeEnabled = $phpIoncubeEnabled;
+
+        return $this;
+    }
+
+    public function isPhpSessionSpreadEnabled(): ?bool
+    {
+        return $this->phpSessionSpreadEnabled;
+    }
+
+    public function setPhpSessionSpreadEnabled(?bool $phpSessionSpreadEnabled): self
+    {
+        $this->phpSessionSpreadEnabled = $phpSessionSpreadEnabled;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): self
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setId(Arr::get($data, 'id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'))
+            ->setPhpVersions(Arr::get($data, 'php_versions', []))
+            ->setCustomPhpModulesNames(Arr::get($data, 'custom_php_modules_names', []))
+            ->setPhpSettings(Arr::get($data, 'php_settings', []))
+            ->setPhpIoncubeEnabled(Arr::get($data, 'php_ioncube_enabled'))
+            ->setPhpSessionSpreadEnabled(Arr::get($data, 'php_session_spread_enabled'))
+            ->setClusterId(Arr::get($data, 'cluster_id'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'php_versions' => $this->getPhpVersions(),
+            'custom_php_modules_names' => $this->getCustomPhpModulesNames(),
+            'php_settings' => new ArrayObject($this->getPhpSettings()),
+            'php_ioncube_enabled' => $this->isPhpIoncubeEnabled(),
+            'php_sessions_spread_enabled' => $this->isPhpSessionSpreadEnabled(),
+        ];
+    }
+}

--- a/src/Models/ClusterRedisProperties.php
+++ b/src/Models/ClusterRedisProperties.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use Cyberfusion\ClusterApi\Support\Arr;
+use Cyberfusion\ClusterApi\Support\Validator;
+
+class ClusterRedisProperties extends ClusterModel
+{
+    private ?int $id = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+    private ?string $redisPassword = null;
+    private ?int $redisMemoryLimit = null;
+    private ?int $clusterId = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getRedisPassword(): ?string
+    {
+        return $this->redisPassword;
+    }
+
+    public function setRedisPassword(?string $redisPassword): self
+    {
+        $this->redisPassword = $redisPassword;
+
+        return $this;
+    }
+
+    public function getRedisMemoryLimit(): ?int
+    {
+        return $this->redisMemoryLimit;
+    }
+
+    public function setRedisMemoryLimit(?int $redisMemoryLimit): self
+    {
+        Validator::value($redisMemoryLimit)
+            ->minAmount(8)
+            ->maxAmount(4096)
+            ->nullable()
+            ->validate();
+
+        $this->redisMemoryLimit = $redisMemoryLimit;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): self
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setId(Arr::get($data, 'id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'))
+            ->setRedisPassword(Arr::get($data, 'redis_password'))
+            ->setRedisMemoryLimit(Arr::get($data, 'redis_memory_limit'))
+            ->setClusterId(Arr::get($data, 'cluster_id'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'redis_password' => $this->getRedisPassword(),
+            'redis_memory_limit' => $this->getRedisMemoryLimit(),
+        ];
+    }
+}

--- a/src/Models/ClusterUnixUserProperties.php
+++ b/src/Models/ClusterUnixUserProperties.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use Cyberfusion\ClusterApi\Support\Arr;
+
+class ClusterUnixUserProperties extends ClusterModel
+{
+    private ?int $id = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+    private ?string $unixUsersHomeDirectory = null;
+    private ?int $clusterId = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getUnixUsersHomeDirectory(): ?string
+    {
+        return $this->unixUsersHomeDirectory;
+    }
+
+    public function setUnixUsersHomeDirectory(?string $unixUsersHomeDirectory): self
+    {
+        $this->unixUsersHomeDirectory = $unixUsersHomeDirectory;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): self
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setId(Arr::get($data, 'id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'))
+            ->setUnixUsersHomeDirectory(Arr::get($data, 'unix_users_home_directory'))
+            ->setClusterId(Arr::get($data, 'cluster_id'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'unix_users_home_directory' => $this->getUnixUsersHomeDirectory(),
+        ];
+    }
+}


### PR DESCRIPTION
Closes https://github.com/CyberfusionIO/cyberfusion-cluster-api-client/issues/136

BE AWARE: I can't test the create/updates as that would affect our clusters.

# Changes

### Added

- Add `readPhpProperties`, `createPhpProperties` and `updatePhpProperties` method to the `Clusters` endpoint.
- Add `readUnixUserProperties` method to the `Clusters` endpoint.
- Add `readRedisProperties`, `createRedisProperties` and `updateRedisProperties` method to the `Clusters` endpoint.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Core API version is updated in the README (when applicable)
